### PR TITLE
Updated guides and templates for Flight Compute environments

### DIFF
--- a/gridscheduler/docs/guides/05-run-jobs.md
+++ b/gridscheduler/docs/guides/05-run-jobs.md
@@ -110,15 +110,15 @@ your requirements:
 
    A simple job script for submitting single thread workflows.
 
- * `mpi-multislot`:
+ * `mpi-slots`:
 
    A job script to run workflows/applications that will run on
    multiple cores which don't necessarily have to be on the same
    compute node (e.g. MPI).
 
- * `mpi-multinode`:
+ * `mpi-nodes`:
 
-   Similar to `mpi-multislot` but with exclusive use of each allocated
+   Similar to `mpi-slots` but with exclusive use of each allocated
    node.
 
  * `smp`:

--- a/gridscheduler/docs/templates/mpi-nodes.sh.tpl
+++ b/gridscheduler/docs/templates/mpi-nodes.sh.tpl
@@ -181,6 +181,14 @@
 # Load the OpenMPI module for access to `mpirun` command
 module load mpi/openmpi
 
+#===========================
+#  Create output directory
+#---------------------------
+# Specify and create an output file directory.
+
+OUTPUT_PATH="$(pwd)/${JOB_NAME}-outputs/$JOB_ID"
+mkdir -p "$OUTPUT_PATH"
+
 #===============================
 #  Application launch commands
 #-------------------------------
@@ -190,4 +198,5 @@ echo "Executing job commands, current working directory is $(pwd)"
 
 # REPLACE THE FOLLOWING WITH YOUR APPLICATION COMMANDS
 
-mpirun -np 2 -npernode 1 echo "This is an example job, I ran on $NHOSTS hosts and had exclusive access to the hosts on which I ran. My master thread ran on `hostname -s` as `whoami`"
+mpirun -np 2 -npernode 1 echo "This is an example job, I ran on $NHOSTS hosts and had exclusive access to the hosts on which I ran. My master thread ran on `hostname -s` as `whoami`" > $OUTPUT_PATH/test.output
+echo "Output file has been generated, please check $OUTPUT_PATH/test.output"

--- a/gridscheduler/docs/templates/mpi-nodes.sh.tpl
+++ b/gridscheduler/docs/templates/mpi-nodes.sh.tpl
@@ -142,7 +142,7 @@
 #     Specify a `G` suffix to request gigabytes. e.g. specify `61140`
 #     or `60G` for 60 gigabytes.
 #
-#$ -l h_vmem=60G
+#$ -l h_vmem=2G
 
 #========================
 #  Parallel environment
@@ -181,14 +181,6 @@
 # Load the OpenMPI module for access to `mpirun` command
 module load mpi/openmpi
 
-#===========================
-#  Create output directory
-#---------------------------
-# Specify and create an output file directory.
-
-OUTPUT_PATH="$(pwd)/$JOB_NAME/$JOB_ID"
-mkdir -p "$OUTPUT_PATH"
-
 #===============================
 #  Application launch commands
 #-------------------------------
@@ -198,6 +190,4 @@ echo "Executing job commands, current working directory is $(pwd)"
 
 # REPLACE THE FOLLOWING WITH YOUR APPLICATION COMMANDS
 
-mpirun -np 24 -npernode 12 echo "This is an example job, I ran on $NHOSTS hosts and had exclusive access to the hosts on which I ran. My master thread ran on `hostname -s` as `whoami`" > $OUTPUT_PATH/test.output
-
-echo "Output file has been generated, please check $OUTPUT_PATH/test.output"
+mpirun -np 2 -npernode 1 echo "This is an example job, I ran on $NHOSTS hosts and had exclusive access to the hosts on which I ran. My master thread ran on `hostname -s` as `whoami`"

--- a/gridscheduler/docs/templates/mpi-slots.sh.tpl
+++ b/gridscheduler/docs/templates/mpi-slots.sh.tpl
@@ -181,6 +181,14 @@
 # Load the OpenMPI module for access to `mpirun` command
 module load mpi/openmpi
 
+#===========================
+#  Create output directory
+#---------------------------
+# Specify and create an output file directory.
+
+OUTPUT_PATH="$(pwd)/${JOB_NAME}-outputs/$JOB_ID"
+mkdir -p "$OUTPUT_PATH"
+
 #===============================
 #  Application launch commands
 #-------------------------------
@@ -190,4 +198,5 @@ echo "Executing job commands, current working directory is $(pwd)"
 
 # REPLACE THE FOLLOWING WITH YOUR APPLICATION COMMANDS
 
-mpirun echo "This is an example job, I ran on $NSLOTS threads using $NHOSTS hosts. My master thread ran on `hostname -s` as `whoami`"
+mpirun echo "This is an example job, I ran on $NSLOTS threads using $NHOSTS hosts. My master thread ran on `hostname -s` as `whoami`" > $OUTPUT_PATH/test.output
+echo "Output file has been generated, please check $OUTPUT_PATH/test.output"

--- a/gridscheduler/docs/templates/mpi-slots.sh.tpl
+++ b/gridscheduler/docs/templates/mpi-slots.sh.tpl
@@ -142,7 +142,7 @@
 #     Specify a `G` suffix to request gigabytes. e.g. specify `4096`
 #     or `4G` for 4 gigabytes.
 #
-#$ -l h_vmem=4G
+#$ -l h_vmem=2G
 
 #========================
 #  Parallel environment
@@ -181,14 +181,6 @@
 # Load the OpenMPI module for access to `mpirun` command
 module load mpi/openmpi
 
-#===========================
-#  Create output directory
-#---------------------------
-# Specify and create an output file directory.
-
-OUTPUT_PATH="$(pwd)/$JOB_NAME/$JOB_ID"
-mkdir -p "$OUTPUT_PATH"
-
 #===============================
 #  Application launch commands
 #-------------------------------
@@ -198,5 +190,4 @@ echo "Executing job commands, current working directory is $(pwd)"
 
 # REPLACE THE FOLLOWING WITH YOUR APPLICATION COMMANDS
 
-mpirun echo "This is an example job, I ran on $NSLOTS threads using $NHOSTS hosts. My master thread ran on `hostname -s` as `whoami`" > $OUTPUT_PATH/test.output
-echo "Output file has been generated, please check $OUTPUT_PATH/test.output"
+mpirun echo "This is an example job, I ran on $NSLOTS threads using $NHOSTS hosts. My master thread ran on `hostname -s` as `whoami`"

--- a/gridscheduler/docs/templates/simple-array.sh.tpl
+++ b/gridscheduler/docs/templates/simple-array.sh.tpl
@@ -164,6 +164,14 @@
 # e.g.:
 # module load apps/imb
 
+#===========================
+#  Create output directory
+#---------------------------
+# Specify and create an output file directory.
+
+OUTPUT_PATH="$(pwd)/${JOB_NAME}-outputs/$JOB_ID"
+mkdir -p "$OUTPUT_PATH"
+
 #===============================
 #  Application launch commands
 #-------------------------------
@@ -173,4 +181,5 @@ echo "Executing job commands, current working directory is $(pwd)"
 
 # REPLACE THE FOLLOWING WITH YOUR APPLICATION COMMANDS
 
-echo "This is an example array job, I was task number $SGE_TASK_ID and I ran on `hostname -s` as `whoami`"
+echo "This is an example array job, I was task number $SGE_TASK_ID and I ran on `hostname -s` as `whoami`" > $OUTPUT_PATH/test.output.$SGE_TASK_ID
+echo "Output file has been generated, please check $OUTPUT_PATH/test.output"

--- a/gridscheduler/docs/templates/simple-array.sh.tpl
+++ b/gridscheduler/docs/templates/simple-array.sh.tpl
@@ -137,7 +137,7 @@
 # megabytes.  Specify a `G` suffix to request gigabytes.
 # e.g. specify `4096` or `4G` for 4 gigabytes.
 #
-#$ -l h_vmem=4G
+#$ -l h_vmem=1G
 
 #=======================
 #  Array configuration
@@ -164,14 +164,6 @@
 # e.g.:
 # module load apps/imb
 
-#===========================
-#  Create output directory
-#---------------------------
-# Specify and create an output file directory.
-
-OUTPUT_PATH="$(pwd)/$JOB_NAME/$JOB_ID"
-mkdir -p "$OUTPUT_PATH"
-
 #===============================
 #  Application launch commands
 #-------------------------------
@@ -181,6 +173,4 @@ echo "Executing job commands, current working directory is $(pwd)"
 
 # REPLACE THE FOLLOWING WITH YOUR APPLICATION COMMANDS
 
-echo "This is an example array job, I was task number $SGE_TASK_ID and I ran on `hostname -s` as `whoami`" > $OUTPUT_PATH/test.output.$SGE_TASK_ID
-
-echo "Output file has been generated, please check $OUTPUT_PATH/test.output"
+echo "This is an example array job, I was task number $SGE_TASK_ID and I ran on `hostname -s` as `whoami`"

--- a/gridscheduler/docs/templates/simple.sh.tpl
+++ b/gridscheduler/docs/templates/simple.sh.tpl
@@ -159,6 +159,14 @@
 # e.g.:
 # module load apps/imb
 
+#===========================
+#  Create output directory
+#---------------------------
+# Specify and create an output file directory.
+
+OUTPUT_PATH="$(pwd)/${JOB_NAME}-outputs/$JOB_ID"
+mkdir -p "$OUTPUT_PATH"
+
 #===============================
 #  Application launch commands
 #-------------------------------
@@ -168,4 +176,5 @@ echo "Executing job commands, current working directory is $(pwd)"
 
 # REPLACE THE FOLLOWING WITH YOUR APPLICATION COMMANDS
 
-echo "This is an example job, I ran on `hostname -s` as `whoami`"
+echo "This is an example job, I ran on `hostname -s` as `whoami`" > $OUTPUT_PATH/test.output
+echo "Output file has been generated, please check $OUTPUT_PATH/test.output"

--- a/gridscheduler/docs/templates/simple.sh.tpl
+++ b/gridscheduler/docs/templates/simple.sh.tpl
@@ -138,7 +138,7 @@
 # megabytes.  Specify a `G` suffix to request gigabytes.
 # e.g. specify `4096` or `4G` for 4 gigabytes.
 #
-#$ -l h_vmem=4G
+#$ -l h_vmem=1G
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
 #  >>>> SET TASK ENVIRONMENT VARIABLES
@@ -159,14 +159,6 @@
 # e.g.:
 # module load apps/imb
 
-#===========================
-#  Create output directory
-#---------------------------
-# Specify and create an output file directory.
-
-OUTPUT_PATH="$(pwd)/$JOB_NAME/$JOB_ID"
-mkdir -p "$OUTPUT_PATH"
-
 #===============================
 #  Application launch commands
 #-------------------------------
@@ -176,5 +168,4 @@ echo "Executing job commands, current working directory is $(pwd)"
 
 # REPLACE THE FOLLOWING WITH YOUR APPLICATION COMMANDS
 
-echo "This is an example job, I ran on `hostname -s` as `whoami`" > $OUTPUT_PATH/test.output
-echo "Output file has been generated, please check $OUTPUT_PATH/test.output"
+echo "This is an example job, I ran on `hostname -s` as `whoami`"

--- a/gridscheduler/docs/templates/smp.sh.tpl
+++ b/gridscheduler/docs/templates/smp.sh.tpl
@@ -183,6 +183,14 @@
 # e.g.:
 # module load apps/imb
 
+#===========================
+#  Create output directory
+#---------------------------
+# Specify and create an output file directory.
+
+OUTPUT_PATH="$(pwd)/${JOB_NAME}-outputs/$JOB_ID"
+mkdir -p "$OUTPUT_PATH"
+
 #===============================
 #  Application launch commands
 #-------------------------------
@@ -192,4 +200,5 @@ echo "Executing job commands, current working directory is $(pwd)"
 
 # REPLACE THE FOLLOWING WITH YOUR APPLICATION COMMANDS
 
-echo "This is an example job, I was allocated $NSLOTS slots on host `hostname -s` as `whoami`"
+echo "This is an example job, I was allocated $NSLOTS slots on host `hostname -s` as `whoami`" > $OUTPUT_PATH/test.output
+echo "Output file has been generated, please check $OUTPUT_PATH/test.output"

--- a/gridscheduler/docs/templates/smp.sh.tpl
+++ b/gridscheduler/docs/templates/smp.sh.tpl
@@ -142,7 +142,7 @@
 #     Specify a `G` suffix to request gigabytes. e.g. specify `4096`
 #     or `4G` for 4 gigabytes.
 #
-#$ -l h_vmem=4G
+#$ -l h_vmem=1G
 
 #========================
 #  Parallel environment
@@ -183,14 +183,6 @@
 # e.g.:
 # module load apps/imb
 
-#===========================
-#  Create output directory
-#---------------------------
-# Specify and create an output file directory.
-
-OUTPUT_PATH="$(pwd)/$JOB_NAME/$JOB_ID"
-mkdir -p "$OUTPUT_PATH"
-
 #===============================
 #  Application launch commands
 #-------------------------------
@@ -200,5 +192,4 @@ echo "Executing job commands, current working directory is $(pwd)"
 
 # REPLACE THE FOLLOWING WITH YOUR APPLICATION COMMANDS
 
-echo "This is an example job, I was allocated $NSLOTS slots on host `hostname -s` as `whoami`" > $OUTPUT_PATH/test.output
-echo "Output file has been generated, please check $OUTPUT_PATH/test.output"
+echo "This is an example job, I was allocated $NSLOTS slots on host `hostname -s` as `whoami`"


### PR DESCRIPTION
- Updated some of the wording to match the displayed names in `alces template`
- Lowered the default resource requirement for running the `alces template` jobs to suit Cloud environments
- The output file directory creation in each of the templates would fail, so I've removed - as each of the templates already have their output file set through the SGE directive
