### PR TITLE
Scheduler howto docs for 1.6 release

### DIFF
--- a/gridscheduler/docs/guides/05-run-jobs.md
+++ b/gridscheduler/docs/guides/05-run-jobs.md
@@ -67,10 +67,11 @@ Calling `qrsh` on its own will allocate all the default resource
 limits, however you can request more resources for your `qrsh` session
 by specifying them on the command line. For example:
 
- * `-l h_rt=72:0:0`:
+ * `-l h_rt=2:0:0`:
 
-   How long you will potentially keep the session open for (hh:mm:ss);
-   the session will be terminated when this time is exceeded
+   How long (in hourse, minutes and seconds) you will potentially keep
+   the session open for; the session will be terminated when this time
+   is exceeded.
 
  * `-l h_vmem=4g`:
 
@@ -84,7 +85,7 @@ by specifying them on the command line. For example:
  * `-pe smp 2`:
 
    Inform the scheduler that you intend to run a multi-core job across
-   two cores
+   two cores.
 
 Use the command `man qrsh` for more specific information on using
 `qrsh`.
@@ -148,4 +149,4 @@ information.
 
 ## COPYRIGHT
 
-Copyright (C) 2009-2015 Alces Software Ltd.
+Copyright (C) 2009-2016 Alces Software Ltd.

--- a/openlava/docs/guides/05-run-jobs.md
+++ b/openlava/docs/guides/05-run-jobs.md
@@ -36,8 +36,8 @@ your best guess for the resources it will require. If you find the job
 gets terminated, increase your resource request to allow your job to
 run. It's often worth starting with the defaults as these are usually
 sufficient for most applications and then alter them if you have
-problems. Once your job has run for the first time, you can use 
-`bjobs <JOB_ID>` to ascertain how much resource your job actually used 
+problems. Once your job has run for the first time, you can use
+`bjobs <JOB_ID>` to ascertain how much resource your job actually used
 and then tune your request accordingly in future runs.
 
 Requesting resources as close to your jobs requirements as possible
@@ -48,7 +48,7 @@ use jobs with smaller resource requests to backfill if it knows that
 the smaller job will complete before enough resources will become
 available for a larger, potentially higher priority, job to
 start. This allows users requesting the correct resources &mdash; in
-particular `-W` (runtime) and `-R "rusage[mem=xxxMB]"` (maximum memory usage)
+particular `-W` (runtime) and `-R "rusage[mem=<n>]"` (maximum memory usage)
 &mdash; to jump the queue and start their jobs more quickly.
 
 ## INTERACTIVE JOBS
@@ -69,8 +69,8 @@ session by specifying them on the command line. For example:
 
  * `-W 120`:
 
-   How long you will potentially keep the session open for (minutes);
-   the session will be terminated when this time is exceeded
+   How long (in minutes) you will potentially keep the session open
+   for; the session will be terminated when this time is exceeded.
 
  * `-R "rusage[mem=4096]`:
 
@@ -84,7 +84,7 @@ session by specifying them on the command line. For example:
  * `-n 2`:
 
    Inform the scheduler that you intend to run a multi-core job across
-   two cores
+   two cores.
 
 Use the command `man bsub` for more specific information on interactive
 session creation.
@@ -100,10 +100,10 @@ your workflow script if your workflow script is written in bash or by
 writing a bash submission script that calls your workflow script).
 
 Your job submission scripts can be submitted to the HPC job scheduler
-via the `bsub` command. You can provide options for your submitted job 
+via the `bsub` command. You can provide options for your submitted job
 either through the job submission command, or more reliably by including
 them within your job submission script. Any submission directives included
-within the job script must begin the line with: 
+within the job script must begin the line with:
 
   `#BSUB <option>`
 

--- a/openlava/docs/guides/05-run-jobs.md
+++ b/openlava/docs/guides/05-run-jobs.md
@@ -1,0 +1,141 @@
+# run-jobs(7) -- How to run jobs
+
+## DESCRIPTION
+
+Applications available within the compute environment may run in
+either an interactive or a batch mode. This guide explains the
+difference between these two types of execution and how they interact
+with the job scheduler.
+
+## OVERVIEW
+
+Some applications installed within the compute environment are
+interactive; this means that to run the application requires you to be
+logged in with an interactive session. When that sessions terminates -
+so does the application. These are typically applications such as
+interactive command line tools or graphical tools. For more
+information on running graphical jobs refer to the "How to run
+graphical jobs" guide ([run-graphical-jobs](run-graphical-jobs)).
+
+However, some applications are non-interactive and you are able to
+pass them a number of command-line parameters (for example input and
+output files) and they then run for a number of minutes / hours / days
+processing data.
+
+## THE SCHEDULER
+
+All jobs to be executed within the compute environment must be
+submitted through the job scheduler. This ensures fair usage as well
+as making sure your job gets the best of the available resources
+allocated to it. Whilst you can login to the compute nodes directly to
+check on your jobs (via `ssh`), any processes on compute nodes that
+are run outside of the scheduler are automatically swept periodically.
+
+When submitting new job requests to the scheduler, you should make
+your best guess for the resources it will require. If you find the job
+gets terminated, increase your resource request to allow your job to
+run. It's often worth starting with the defaults as these are usually
+sufficient for most applications and then alter them if you have
+problems. Once your job has run for the first time, you can use `qacct
+-j <JOB_ID>` to ascertain how much resource your job actually used and
+then tune your request accordingly in future runs.
+
+Requesting resources as close to your jobs requirements as possible
+will ensure that your job is scheduled as quickly as possible. Jobs
+that request more resource will potentially queue for longer as they
+need to wait for more resources to become available. The scheduler can
+use jobs with smaller resource requests to backfill if it knows that
+the smaller job will complete before enough resources will become
+available for a larger, potentially higher priority, job to
+start. This allows users requesting the correct resources &mdash; in
+particular `h_rt` (runtime) and `h_vmem` (maximum memory usage)
+&mdash; to jump the queue and start their jobs more quickly.
+
+## INTERACTIVE JOBS
+
+Interactive jobs can be run via the scheduler using the interactive
+shell command `bsub -Is bash`. Running the command will allocate you
+a single slot on an available compute node and give you a shell on that
+node. From there you can then load your required application modules and
+start running.
+
+Often when experimenting with a new application it can be useful to
+start an interactive session to understand the way it behaves and the
+command line options available before you write a job script.
+
+Calling `bsub -Is bash` on its own will allocate all the default resource
+limits, however you can request more resources for your interactive
+session by specifying them on the command line. For example:
+
+ * `-W 120`:
+
+   How long you will potentially keep the session open for (mm);
+   the session will be terminated when this time is exceeded
+
+ * `-R "rusage[mem=4096]`:
+
+   How much memory you will potentially want to use in this session;
+   the session will be terminated if you use more than you
+   request. Note that this request is per slot, so if you are
+   requesting multiple slots/cores for your job, you should divide the
+   total amount of memory you want to use by the number of slots you
+   are requesting.
+
+ * `-n 2`:
+
+   Inform the scheduler that you intend to run a multi-core job across
+   two cores
+
+Use the command `man bsub` for more specific information on interactive
+session creation.
+
+
+## BATCH (SCRIPTED) JOBS
+
+Most HPC workflows can be scripted; the resulting job script may be
+submitted to the HPC job scheduler to run multiple times, potentially
+with different datasets each time. Your job scripts can include
+scheduler instructions (either by placing scheduler tags directly in
+your workflow script if your workflow script is written in bash or by
+writing a bash submission script that calls your workflow script).
+
+Your job submission scripts can be submitted to the HPC job scheduler
+via the `bsub` command. You can provide options for your submitted job 
+either through the job submission command, or more reliably by including
+them within your job submission script. Any submission directives included
+within the job script must begin the line with: 
+
+  `#BSUB <option>`
+
+You can submit a basic job script to the cluster scheduler with the
+following example command:
+
+  `bsub < my_example_job.sh`
+
+Use the command `man bsub` for more specific information on using `bsub`.
+
+## CHECKING JOB STATUS
+
+You can view the status of the cluster scheduler queues, viewing information
+about any running jobs. The cluster scheduler queue can be queried with the
+following example command:
+
+  `bjobs [job-ID]`
+
+Use the command `bjobs` for more specific information on using `bjobs`.
+
+## SEE ALSO
+
+run-graphical-jobs, bsub(1), bjobs(1)
+
+## LICENSE
+
+This work is licensed under a Creative Commons Attribution-ShareAlike
+4.0 International License.
+
+See <http://creativecommons.org/licenses/by-sa/4.0/> for more
+information.
+
+## COPYRIGHT
+
+Copyright (C) 2009-2016 Alces Software Ltd.

--- a/openlava/docs/guides/05-run-jobs.md
+++ b/openlava/docs/guides/05-run-jobs.md
@@ -36,9 +36,9 @@ your best guess for the resources it will require. If you find the job
 gets terminated, increase your resource request to allow your job to
 run. It's often worth starting with the defaults as these are usually
 sufficient for most applications and then alter them if you have
-problems. Once your job has run for the first time, you can use `qacct
--j <JOB_ID>` to ascertain how much resource your job actually used and
-then tune your request accordingly in future runs.
+problems. Once your job has run for the first time, you can use 
+`bjobs <JOB_ID>` to ascertain how much resource your job actually used 
+and then tune your request accordingly in future runs.
 
 Requesting resources as close to your jobs requirements as possible
 will ensure that your job is scheduled as quickly as possible. Jobs
@@ -48,7 +48,7 @@ use jobs with smaller resource requests to backfill if it knows that
 the smaller job will complete before enough resources will become
 available for a larger, potentially higher priority, job to
 start. This allows users requesting the correct resources &mdash; in
-particular `h_rt` (runtime) and `h_vmem` (maximum memory usage)
+particular `-W` (runtime) and `-R "rusage[mem=xxxMB]"` (maximum memory usage)
 &mdash; to jump the queue and start their jobs more quickly.
 
 ## INTERACTIVE JOBS
@@ -69,12 +69,12 @@ session by specifying them on the command line. For example:
 
  * `-W 120`:
 
-   How long you will potentially keep the session open for (mm);
+   How long you will potentially keep the session open for (minutes);
    the session will be terminated when this time is exceeded
 
  * `-R "rusage[mem=4096]`:
 
-   How much memory you will potentially want to use in this session;
+   How much memory (in MB) you will potentially want to use in this session;
    the session will be terminated if you use more than you
    request. Note that this request is per slot, so if you are
    requesting multiple slots/cores for your job, you should divide the

--- a/openlava/docs/guides/10-run-graphical-jobs.md
+++ b/openlava/docs/guides/10-run-graphical-jobs.md
@@ -1,0 +1,46 @@
+# run-graphical-jobs(7) -- How to run graphical jobs
+
+## DESCRIPTION
+
+This guide will help you start your graphical applications in the
+correct way within your compute environment.
+
+## OVERVIEW
+
+Graphical applications should be run within the compute environment by
+submitting them to the job scheduler system.  Running your
+applications in this way will provide them with access to scalable
+resources.
+
+## PROCEDURE
+
+Login to your graphical desktop and start a new terminal shell. At
+this point, you are logged in to a login node within the compute
+environment - applications should be submitted to the HPC job
+scheduler and not run on the login node directly.
+
+To get an interactive session, use the `bsub -Is bash` command from a 
+shell window on your graphical desktop; you may use the same syntax as the
+`bsub` command to request additional resources for your interactive
+shell. For example, to request an interactive session with access to 32GB 
+of RAM and a maximum runtime of 2 hours, use the command:
+
+    [user@login1(cluster) ~]$ bsub -R "rusage[mem=32768]" -W "120" -Is bash
+
+You may then begin loading the required modules and loading your applications.
+
+## SEE ALSO
+
+bsub(1)
+
+## LICENSE
+
+This work is licensed under a Creative Commons Attribution-ShareAlike
+4.0 International License.
+
+See <http://creativecommons.org/licenses/by-sa/4.0/> for more
+information.
+
+## COPYRIGHT
+
+Copyright (C) 2009-2015 Alces Software Ltd.

--- a/pbspro/docs/guides/05-run-jobs.md
+++ b/pbspro/docs/guides/05-run-jobs.md
@@ -1,0 +1,136 @@
+# run-jobs(5) -- How to run jobs
+
+## DESCRIPTION
+
+Applications available within the compute environment may run in
+either an interactive or a batch mode. This guide explains the
+difference between these two types of execution and how they interact
+with the job scheduler.
+
+## OVERVIEW
+
+Some applications installed within the compute environment are
+interactive; this means that to run the application requires you to be
+logged in with an interactive session. When that sessions terminates -
+so does the application. These are typically applications such as
+interactive command line tools or graphical tools. For more
+information on running graphical jobs refer to the "How to run
+graphical jobs" guide ([run-graphical-jobs](run-graphical-jobs)).
+
+However, some applications are non-interactive and you are able to
+pass them a number of command-line parameters (for example input and
+output files) and they then run for a number of minutes / hours / days
+processing data.
+
+## THE SCHEDULER
+
+All jobs to be executed within the compute environment must be
+submitted through the job scheduler. This ensures fair usage as well
+as making sure your job gets the best of the available resources
+allocated to it. Whilst you can login to the compute nodes directly to
+check on your jobs (via `ssh`), any processes on compute nodes that
+are run outside of the scheduler are automatically swept periodically.
+
+When submitting new job requests to the scheduler, you should make
+your best guess for the resources it will require. If you find the job
+gets terminated, increase your resource request to allow your job to
+run. It's often worth starting with the defaults as these are usually
+sufficient for most applications and then alter them if you have
+problems. 
+
+Requesting resources as close to your jobs requirements as possible
+will ensure that your job is scheduled as quickly as possible. Jobs
+that request more resource will potentially queue for longer as they
+need to wait for more resources to become available. The scheduler can
+use jobs with smaller resource requests to backfill if it knows that
+the smaller job will complete before enough resources will become
+available for a larger, potentially higher priority, job to
+start. This allows users requesting the correct resources &mdash; in
+particular `-l walltime=[hh:mm:ss]` (runtime) and `-l mem=[mb]` (maximum
+memory usage) &mdash; to jump the queue and start their jobs more quickly.
+
+## INTERACTIVE JOBS
+
+Interactive jobs can be run via the scheduler using the interactive
+shell command `qsub -I`. Running `qsub -I` will launch an interactive
+session which will allocate you a shell on the chosen compute node. 
+From there, you can then load your required application modules and 
+start running.
+
+Often when experimenting with a new application it can be useful to
+start an interactive session to understand the way it behaves and the
+command line options available before you write a job script.
+
+You can optionally choose to provide information to the scheduler
+about the interactive session you are creating - for example duration,
+maximum memory, number of CPU cores to allocate. These can be provided
+using some of the following options together with the above `qsub -I`
+command.
+
+ * `-l walltime=[hh:mm:ss]`:
+
+   How long you will potentially keep the session open for (d-hh:mm);
+   the session will be terminated when this time is exceeded
+
+ * `-l mem=512mb`:
+
+   How much memory you will potentially want to use in this session.
+   Note that this request is per node, not per core requested. The
+   above option will indicate you wish to use 512MB memory. 
+
+ * `-l ncpus=2`:
+
+   Inform the scheduler that you intend to run a multi-core job across
+   two cores
+
+Use the command `man qsub` for more specific information on using
+`qsub`.
+
+## BATCH (SCRIPTED) JOBS
+
+Most HPC workflows can be scripted; the resulting job script may be
+submitted to the HPC job scheduler to run multiple times, potentially
+with different datasets each time. Your job scripts can include
+scheduler instructions (either by placing scheduler tags directly in
+your workflow script if your workflow script is written in bash or by
+writing a bash submission script that calls your workflow script).
+
+Your job submission scripts can be submitted to the HPC job scheduler
+via the `qsub` command. You can provide options for your submitted job
+either through the job submission command, or more reliably by including
+them within your job submission script. 
+
+You can submit a basic job script to the cluster scheduler with the
+following example command:
+
+   `qsub my_example_job.sh`
+
+Use the command `man qsub` for more specific information on using
+`qsub`.
+
+## CHECKING JOB STATUS
+
+You can view the status of the cluster scheduler queues, viewing information
+about any running jobs. The cluster scheduler queue can be queried with the
+following example command: 
+
+   `qstat`
+
+Use the command `man qstat` for more specific information on using 
+`qstat`.
+
+## SEE ALSO
+
+run-graphical-jobs, qstat(1), qsub(1)
+
+## LICENSE
+
+This work is licensed under a Creative Commons Attribution-ShareAlike
+4.0 International License.
+
+See <http://creativecommons.org/licenses/by-sa/4.0/> for more
+information.
+
+## COPYRIGHT
+
+Copyright (C) 2009-2016 Alces Software Ltd.

--- a/pbspro/docs/guides/05-run-jobs.md
+++ b/pbspro/docs/guides/05-run-jobs.md
@@ -69,7 +69,7 @@ command.
 
  * `-l walltime=[hh:mm:ss]`:
 
-   How long you will potentially keep the session open for (d-hh:mm);
+   How long you will potentially keep the session open for (hh:mm:ss);
    the session will be terminated when this time is exceeded
 
  * `-l mem=512mb`:

--- a/pbspro/docs/guides/05-run-jobs.md
+++ b/pbspro/docs/guides/05-run-jobs.md
@@ -36,7 +36,7 @@ your best guess for the resources it will require. If you find the job
 gets terminated, increase your resource request to allow your job to
 run. It's often worth starting with the defaults as these are usually
 sufficient for most applications and then alter them if you have
-problems. 
+problems.
 
 Requesting resources as close to your jobs requirements as possible
 will ensure that your job is scheduled as quickly as possible. Jobs
@@ -46,15 +46,15 @@ use jobs with smaller resource requests to backfill if it knows that
 the smaller job will complete before enough resources will become
 available for a larger, potentially higher priority, job to
 start. This allows users requesting the correct resources &mdash; in
-particular `-l walltime=[hh:mm:ss]` (runtime) and `-l mem=[mb]` (maximum
+particular `-l walltime=<hh:mm:ss>` (runtime) and `-l mem=<n>` (maximum
 memory usage) &mdash; to jump the queue and start their jobs more quickly.
 
 ## INTERACTIVE JOBS
 
 Interactive jobs can be run via the scheduler using the interactive
 shell command `qsub -I`. Running `qsub -I` will launch an interactive
-session which will allocate you a shell on the chosen compute node. 
-From there, you can then load your required application modules and 
+session which will allocate you a shell on the chosen compute node.
+From there, you can then load your required application modules and
 start running.
 
 Often when experimenting with a new application it can be useful to
@@ -67,21 +67,22 @@ maximum memory, number of CPU cores to allocate. These can be provided
 using some of the following options together with the above `qsub -I`
 command.
 
- * `-l walltime=[hh:mm:ss]`:
+ * `-l walltime=2:0:0`:
 
-   How long you will potentially keep the session open for (hh:mm:ss);
-   the session will be terminated when this time is exceeded
+   How long (in hours, minutes and seconds) you will potentially keep
+   the session open for; the session will be terminated when this time
+   is exceeded.
 
  * `-l mem=512mb`:
 
    How much memory you will potentially want to use in this session.
    Note that this request is per node, not per core requested. The
-   above option will indicate you wish to use 512MB memory. 
+   above option will indicate you wish to use 512MB memory.
 
  * `-l ncpus=2`:
 
    Inform the scheduler that you intend to run a multi-core job across
-   two cores
+   two cores.
 
 Use the command `man qsub` for more specific information on using
 `qsub`.
@@ -98,7 +99,7 @@ writing a bash submission script that calls your workflow script).
 Your job submission scripts can be submitted to the HPC job scheduler
 via the `qsub` command. You can provide options for your submitted job
 either through the job submission command, or more reliably by including
-them within your job submission script. 
+them within your job submission script.
 
 You can submit a basic job script to the cluster scheduler with the
 following example command:
@@ -112,11 +113,11 @@ Use the command `man qsub` for more specific information on using
 
 You can view the status of the cluster scheduler queues, viewing information
 about any running jobs. The cluster scheduler queue can be queried with the
-following example command: 
+following example command:
 
    `qstat`
 
-Use the command `man qstat` for more specific information on using 
+Use the command `man qstat` for more specific information on using
 `qstat`.
 
 ## SEE ALSO

--- a/pbspro/docs/guides/10-run-graphical-jobs.md
+++ b/pbspro/docs/guides/10-run-graphical-jobs.md
@@ -1,0 +1,35 @@
+# run-graphical-jobs(7) -- How to run graphical jobs
+
+## DESCRIPTION
+
+This guide will help you start your graphical applications in the correct way within your compute environment.
+
+## OVERVIEW
+
+Graphical applications should be run within the compute environment by submitting them to the job scheduler system. Running your applications in this way will provide them with access to scalable resources.
+
+## PROCEDURE
+
+Login to your graphical desktop and start a new terminal shell. At this point, you are logged in to a login node within the compute environment - applications should be submitted to the HPC job scheduler and not run on the login node directly.
+
+To gain an interactive session on one of the available cluster compute hosts - use the following example command:
+
+    `qsub -I`
+
+You may use the same syntax as the `sbatch` command to request additional resources for your interactive shell. For example, to request an interactive session with access to 32GB of RAM and a maximum runtime of 72 hours, use the following command:
+
+    `qsub -l walltime=72:00:00,mem=32768mb -I`
+
+## SEE ALSO
+
+qsub(1), qstat(1)
+
+## LICENSE
+
+This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License.
+
+See <http://creativecommons.org/licenses/by-sa/4.0/> for more information.
+
+## COPYRIGHT
+
+Copyright (C) 2009-2016 Alces Software Ltd.

--- a/pbspro/docs/guides/10-run-graphical-jobs.md
+++ b/pbspro/docs/guides/10-run-graphical-jobs.md
@@ -16,7 +16,7 @@ To gain an interactive session on one of the available cluster compute hosts - u
 
     `qsub -I`
 
-You may use the same syntax as the `sbatch` command to request additional resources for your interactive shell. For example, to request an interactive session with access to 32GB of RAM and a maximum runtime of 72 hours, use the following command:
+You may use the same syntax as the `qsub` command to request additional resources for your interactive shell. For example, to request an interactive session with access to 32GB of RAM and a maximum runtime of 72 hours, use the following command:
 
     `qsub -l walltime=72:00:00,mem=32768mb -I`
 

--- a/slurm/docs/guides/05-run-jobs.md
+++ b/slurm/docs/guides/05-run-jobs.md
@@ -121,7 +121,7 @@ following example command:
    `squeue`
 
 Use the command `man squeue` for more specific information on using 
-`sequeue`.
+`squeue`.
 
 ## SEE ALSO
 

--- a/slurm/docs/guides/05-run-jobs.md
+++ b/slurm/docs/guides/05-run-jobs.md
@@ -1,0 +1,140 @@
+# run-jobs(5) -- How to run jobs
+
+## DESCRIPTION
+
+Applications available within the compute environment may run in
+either an interactive or a batch mode. This guide explains the
+difference between these two types of execution and how they interact
+with the job scheduler.
+
+## OVERVIEW
+
+Some applications installed within the compute environment are
+interactive; this means that to run the application requires you to be
+logged in with an interactive session. When that sessions terminates -
+so does the application. These are typically applications such as
+interactive command line tools or graphical tools. For more
+information on running graphical jobs refer to the "How to run
+graphical jobs" guide ([run-graphical-jobs](run-graphical-jobs)).
+
+However, some applications are non-interactive and you are able to
+pass them a number of command-line parameters (for example input and
+output files) and they then run for a number of minutes / hours / days
+processing data.
+
+## THE SCHEDULER
+
+All jobs to be executed within the compute environment must be
+submitted through the job scheduler. This ensures fair usage as well
+as making sure your job gets the best of the available resources
+allocated to it. Whilst you can login to the compute nodes directly to
+check on your jobs (via `ssh`), any processes on compute nodes that
+are run outside of the scheduler are automatically swept periodically.
+
+When submitting new job requests to the scheduler, you should make
+your best guess for the resources it will require. If you find the job
+gets terminated, increase your resource request to allow your job to
+run. It's often worth starting with the defaults as these are usually
+sufficient for most applications and then alter them if you have
+problems. 
+
+Requesting resources as close to your jobs requirements as possible
+will ensure that your job is scheduled as quickly as possible. Jobs
+that request more resource will potentially queue for longer as they
+need to wait for more resources to become available. The scheduler can
+use jobs with smaller resource requests to backfill if it knows that
+the smaller job will complete before enough resources will become
+available for a larger, potentially higher priority, job to
+start. This allows users requesting the correct resources &mdash; in
+particular `--time` (runtime) and `--mem` (maximum memory usage)
+&mdash; to jump the queue and start their jobs more quickly.
+
+## INTERACTIVE JOBS
+
+Interactive jobs can be run via the scheduler using the interactive
+shell command `srun`. Running `srun` with the required options
+will allocate you a shell on the chosen compute node. From there,
+you can then load your required application modules and start running.
+
+Often when experimenting with a new application it can be useful to
+start an interactive session to understand the way it behaves and the
+command line options available before you write a job script.
+
+The following command can be used to gain an interactive session on
+a cluster compute node: 
+
+   `srun --pty /bin/bash`
+
+You can optionally choose to provide information to the scheduler
+about the interactive session you are creating - for example duration,
+maximum memory, number of CPU cores to allocate. These can be provided
+using some of the following options together with the above `srun`
+command.
+
+ * `--time=0-2:00`:
+
+   How long you will potentially keep the session open for (d-hh:mm);
+   the session will be terminated when this time is exceeded
+
+ * `--mem 512`:
+
+   How much memory you will potentially want to use in this session.
+   Note that this request is per node, not per core requested. The
+   above option will indicate you wish to use 512MB memory. 
+
+ * `--ntasks=2`:
+
+   Inform the scheduler that you intend to run a multi-core job across
+   two cores
+
+Use the command `man srun` for more specific information on using
+`srun`.
+
+## BATCH (SCRIPTED) JOBS
+
+Most HPC workflows can be scripted; the resulting job script may be
+submitted to the HPC job scheduler to run multiple times, potentially
+with different datasets each time. Your job scripts can include
+scheduler instructions (either by placing scheduler tags directly in
+your workflow script if your workflow script is written in bash or by
+writing a bash submission script that calls your workflow script).
+
+Your job submission scripts can be submitted to the HPC job scheduler
+via the `sbatch` command. You can provide options for your submitted job
+either through the job submission command, or more reliably by including
+them within your job submission script. 
+
+You can submit a basic job script to the cluster scheduler with the
+following example command:
+
+   `sbatch my_example_job.sh`
+
+Use the command `man sbatch` for more specific information on using
+`sbatch`.
+
+## CHECKING JOB STATUS
+
+You can view the status of the cluster scheduler queues, viewing information
+about any running jobs. The cluster scheduler queue can be queried with the
+following example command: 
+
+   `squeue`
+
+Use the command `man squeue` for more specific information on using 
+`sequeue`.
+
+## SEE ALSO
+
+run-graphical-jobs, sbatch(1), srun(1), squeue(1)
+
+## LICENSE
+
+This work is licensed under a Creative Commons Attribution-ShareAlike
+4.0 International License.
+
+See <http://creativecommons.org/licenses/by-sa/4.0/> for more
+information.
+
+## COPYRIGHT
+
+Copyright (C) 2009-2016 Alces Software Ltd.

--- a/slurm/docs/guides/05-run-jobs.md
+++ b/slurm/docs/guides/05-run-jobs.md
@@ -73,14 +73,15 @@ command.
 
  * `--time=0-2:00`:
 
-   How long you will potentially keep the session open for (d-hh:mm);
-   the session will be terminated when this time is exceeded
+   How long you will potentially keep the session open for
+   (days-hours:mins); the session will be terminated when this time 
+   is exceeded
 
  * `--mem 512`:
 
-   How much memory you will potentially want to use in this session.
-   Note that this request is per node, not per core requested. The
-   above option will indicate you wish to use 512MB memory. 
+   How much memory (in MB) you will potentially want to use in this 
+   session. Note that this request is per node, not per core requested.
+   The above option will indicate you wish to use 512MB memory. 
 
  * `--ntasks=2`:
 

--- a/slurm/docs/guides/05-run-jobs.md
+++ b/slurm/docs/guides/05-run-jobs.md
@@ -36,7 +36,7 @@ your best guess for the resources it will require. If you find the job
 gets terminated, increase your resource request to allow your job to
 run. It's often worth starting with the defaults as these are usually
 sufficient for most applications and then alter them if you have
-problems. 
+problems.
 
 Requesting resources as close to your jobs requirements as possible
 will ensure that your job is scheduled as quickly as possible. Jobs
@@ -75,18 +75,18 @@ command.
 
    How long you will potentially keep the session open for
    (days-hours:mins); the session will be terminated when this time 
-   is exceeded
+   is exceeded.
 
  * `--mem 512`:
 
-   How much memory (in MB) you will potentially want to use in this 
+   How much memory (in MB) you will potentially want to use in this
    session. Note that this request is per node, not per core requested.
-   The above option will indicate you wish to use 512MB memory. 
+   The above option will indicate you wish to use 512MB memory.
 
  * `--ntasks=2`:
 
    Inform the scheduler that you intend to run a multi-core job across
-   two cores
+   two cores.
 
 Use the command `man srun` for more specific information on using
 `srun`.
@@ -117,11 +117,11 @@ Use the command `man sbatch` for more specific information on using
 
 You can view the status of the cluster scheduler queues, viewing information
 about any running jobs. The cluster scheduler queue can be queried with the
-following example command: 
+following example command:
 
    `squeue`
 
-Use the command `man squeue` for more specific information on using 
+Use the command `man squeue` for more specific information on using
 `squeue`.
 
 ## SEE ALSO

--- a/slurm/docs/guides/10-run-graphical-jobs.md
+++ b/slurm/docs/guides/10-run-graphical-jobs.md
@@ -1,0 +1,48 @@
+# run-graphical-jobs(7) -- How to run graphical jobs
+
+## DESCRIPTION
+
+This guide will help you start your graphical applications in the
+correct way within your compute environment.
+
+## OVERVIEW
+
+Graphical applications should be run within the compute environment by
+submitting them to the job scheduler system.  Running your
+applications in this way will provide them with access to scalable
+resources.
+
+## PROCEDURE
+
+Login to your graphical desktop and start a new terminal shell. At
+this point, you are logged in to a login node within the compute
+environment - applications should be submitted to the HPC job
+scheduler and not run on the login node directly.
+
+To gain an interactive session on one of the available cluster
+compute hosts - use the following example command: 
+
+   `srun --pty /bin/bash`
+
+You may use the same syntax as the `sbatch` command to request
+additional resources for your interactive shell. For example, to
+request an interactive session with access to 32GB of RAM and a 
+maximum runtime of 72 hours, use the following command:
+
+   `srun --mem=32768 --time=3-0:00 --pty /bin/bash`
+
+## SEE ALSO
+
+srun(1), sbatch(1)
+
+## LICENSE
+
+This work is licensed under a Creative Commons Attribution-ShareAlike
+4.0 International License.
+
+See <http://creativecommons.org/licenses/by-sa/4.0/> for more
+information.
+
+## COPYRIGHT
+
+Copyright (C) 2009-2015 Alces Software Ltd.

--- a/slurm/docs/guides/10-run-graphical-jobs.md
+++ b/slurm/docs/guides/10-run-graphical-jobs.md
@@ -2,34 +2,23 @@
 
 ## DESCRIPTION
 
-This guide will help you start your graphical applications in the
-correct way within your compute environment.
+This guide will help you start your graphical applications in the correct way within your compute environment.
 
 ## OVERVIEW
 
-Graphical applications should be run within the compute environment by
-submitting them to the job scheduler system.  Running your
-applications in this way will provide them with access to scalable
-resources.
+Graphical applications should be run within the compute environment by submitting them to the job scheduler system. Running your applications in this way will provide them with access to scalable resources.
 
 ## PROCEDURE
 
-Login to your graphical desktop and start a new terminal shell. At
-this point, you are logged in to a login node within the compute
-environment - applications should be submitted to the HPC job
-scheduler and not run on the login node directly.
+Login to your graphical desktop and start a new terminal shell. At this point, you are logged in to a login node within the compute environment - applications should be submitted to the HPC job scheduler and not run on the login node directly.
 
-To gain an interactive session on one of the available cluster
-compute hosts - use the following example command: 
+To gain an interactive session on one of the available cluster compute hosts - use the following example command:
 
-   `srun --pty /bin/bash`
+`srun --pty /bin/bash`
 
-You may use the same syntax as the `sbatch` command to request
-additional resources for your interactive shell. For example, to
-request an interactive session with access to 32GB of RAM and a 
-maximum runtime of 72 hours, use the following command:
+You may use the same syntax as the `sbatch` command to request additional resources for your interactive shell. For example, to request an interactive session with access to 32GB of RAM and a maximum runtime of 72 hours, use the following command:
 
-   `srun --mem=32768 --time=3-0:00 --pty /bin/bash`
+`srun --mem=32768 --time=3-0:00 --pty /bin/bash`
 
 ## SEE ALSO
 
@@ -37,12 +26,10 @@ srun(1), sbatch(1)
 
 ## LICENSE
 
-This work is licensed under a Creative Commons Attribution-ShareAlike
-4.0 International License.
+This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License.
 
-See <http://creativecommons.org/licenses/by-sa/4.0/> for more
-information.
+See <http://creativecommons.org/licenses/by-sa/4.0/> for more information.
 
 ## COPYRIGHT
 
-Copyright (C) 2009-2015 Alces Software Ltd.
+Copyright (C) 2009-2016 Alces Software Ltd.

--- a/torque/docs/guides/05-run-jobs.md
+++ b/torque/docs/guides/05-run-jobs.md
@@ -1,0 +1,136 @@
+# run-jobs(5) -- How to run jobs
+
+## DESCRIPTION
+
+Applications available within the compute environment may run in
+either an interactive or a batch mode. This guide explains the
+difference between these two types of execution and how they interact
+with the job scheduler.
+
+## OVERVIEW
+
+Some applications installed within the compute environment are
+interactive; this means that to run the application requires you to be
+logged in with an interactive session. When that sessions terminates -
+so does the application. These are typically applications such as
+interactive command line tools or graphical tools. For more
+information on running graphical jobs refer to the "How to run
+graphical jobs" guide ([run-graphical-jobs](run-graphical-jobs)).
+
+However, some applications are non-interactive and you are able to
+pass them a number of command-line parameters (for example input and
+output files) and they then run for a number of minutes / hours / days
+processing data.
+
+## THE SCHEDULER
+
+All jobs to be executed within the compute environment must be
+submitted through the job scheduler. This ensures fair usage as well
+as making sure your job gets the best of the available resources
+allocated to it. Whilst you can login to the compute nodes directly to
+check on your jobs (via `ssh`), any processes on compute nodes that
+are run outside of the scheduler are automatically swept periodically.
+
+When submitting new job requests to the scheduler, you should make
+your best guess for the resources it will require. If you find the job
+gets terminated, increase your resource request to allow your job to
+run. It's often worth starting with the defaults as these are usually
+sufficient for most applications and then alter them if you have
+problems. 
+
+Requesting resources as close to your jobs requirements as possible
+will ensure that your job is scheduled as quickly as possible. Jobs
+that request more resource will potentially queue for longer as they
+need to wait for more resources to become available. The scheduler can
+use jobs with smaller resource requests to backfill if it knows that
+the smaller job will complete before enough resources will become
+available for a larger, potentially higher priority, job to
+start. This allows users requesting the correct resources &mdash; in
+particular `-l walltime=[hh:mm:ss]` (runtime) and `-l mem=[mb]` (maximum
+memory usage) &mdash; to jump the queue and start their jobs more quickly.
+
+## INTERACTIVE JOBS
+
+Interactive jobs can be run via the scheduler using the interactive
+shell command `qsub -I`. Running `qsub -I` will launch an interactive
+session which will allocate you a shell on the chosen compute node. 
+From there, you can then load your required application modules and 
+start running.
+
+Often when experimenting with a new application it can be useful to
+start an interactive session to understand the way it behaves and the
+command line options available before you write a job script.
+
+You can optionally choose to provide information to the scheduler
+about the interactive session you are creating - for example duration,
+maximum memory, number of CPU cores to allocate. These can be provided
+using some of the following options together with the above `qsub -I`
+command.
+
+ * `-l walltime=[hh:mm:ss]`:
+
+   How long you will potentially keep the session open for (d-hh:mm);
+   the session will be terminated when this time is exceeded
+
+ * `-l mem=512mb`:
+
+   How much memory you will potentially want to use in this session.
+   Note that this request is per node, not per core requested. The
+   above option will indicate you wish to use 512MB memory. 
+
+ * `-l mppwidth=2`:
+
+   Inform the scheduler that you intend to run a multi-core job across
+   two cores
+
+Use the command `man qsub` for more specific information on using
+`qsub`.
+
+## BATCH (SCRIPTED) JOBS
+
+Most HPC workflows can be scripted; the resulting job script may be
+submitted to the HPC job scheduler to run multiple times, potentially
+with different datasets each time. Your job scripts can include
+scheduler instructions (either by placing scheduler tags directly in
+your workflow script if your workflow script is written in bash or by
+writing a bash submission script that calls your workflow script).
+
+Your job submission scripts can be submitted to the HPC job scheduler
+via the `qsub` command. You can provide options for your submitted job
+either through the job submission command, or more reliably by including
+them within your job submission script. 
+
+You can submit a basic job script to the cluster scheduler with the
+following example command:
+
+   `qsub my_example_job.sh`
+
+Use the command `man qsub` for more specific information on using
+`qsub`.
+
+## CHECKING JOB STATUS
+
+You can view the status of the cluster scheduler queues, viewing information
+about any running jobs. The cluster scheduler queue can be queried with the
+following example command: 
+
+   `qstat`
+
+Use the command `man qstat` for more specific information on using 
+`qstat`.
+
+## SEE ALSO
+
+run-graphical-jobs, qstat(1), qsub(1)
+
+## LICENSE
+
+This work is licensed under a Creative Commons Attribution-ShareAlike
+4.0 International License.
+
+See <http://creativecommons.org/licenses/by-sa/4.0/> for more
+information.
+
+## COPYRIGHT
+
+Copyright (C) 2009-2016 Alces Software Ltd.

--- a/torque/docs/guides/05-run-jobs.md
+++ b/torque/docs/guides/05-run-jobs.md
@@ -69,8 +69,9 @@ command.
 
  * `-l walltime=[hh:mm:ss]`:
 
-   How long you will potentially keep the session open for (d-hh:mm);
-   the session will be terminated when this time is exceeded
+   How long you will potentially keep the session open for 
+   (hours:minutes:seconds); the session will be terminated when this
+   time is exceeded.
 
  * `-l mem=512mb`:
 

--- a/torque/docs/guides/10-run-graphical-jobs.md
+++ b/torque/docs/guides/10-run-graphical-jobs.md
@@ -1,0 +1,35 @@
+# run-graphical-jobs(7) -- How to run graphical jobs
+
+## DESCRIPTION
+
+This guide will help you start your graphical applications in the correct way within your compute environment.
+
+## OVERVIEW
+
+Graphical applications should be run within the compute environment by submitting them to the job scheduler system. Running your applications in this way will provide them with access to scalable resources.
+
+## PROCEDURE
+
+Login to your graphical desktop and start a new terminal shell. At this point, you are logged in to a login node within the compute environment - applications should be submitted to the HPC job scheduler and not run on the login node directly.
+
+To gain an interactive session on one of the available cluster compute hosts - use the following example command:
+
+    `qsub -I`
+
+You may use the same syntax as the `sbatch` command to request additional resources for your interactive shell. For example, to request an interactive session with access to 32GB of RAM and a maximum runtime of 72 hours, use the following command:
+
+    `qsub -l walltime=72:00:00,mem=32768mb -I`
+
+## SEE ALSO
+
+qsub(1), qstat(1)
+
+## LICENSE
+
+This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License.
+
+See <http://creativecommons.org/licenses/by-sa/4.0/> for more information.
+
+## COPYRIGHT
+
+Copyright (C) 2009-2016 Alces Software Ltd.


### PR DESCRIPTION
`alces howto` docs for new schedulers to be included with the 1.6 release. 

Includes; 
- Slurm ( alces-software/clusterware#192 )
- Torque ( alces-software/clusterware#194 )
- OpenLava ( alces-software/clusterware#193 )
- PBS Pro ( alces-software/clusterware#195 )
