### PR TITLE
Include VPN IP address in session start and info output (closes #29)

### DIFF
--- a/clusterware-sessions/lib/functions/vnc.functions.sh
+++ b/clusterware-sessions/lib/functions/vnc.functions.sh
@@ -108,6 +108,7 @@ vnc_write_vars_file() {
     password="$5"
     websocket="$6"
     sessiontype="$7"
+    vpn_address="$8"
 
     metadata_file="${cw_VNC_SESSIONSDIR}/${sessionid}/metadata.vars.sh"
 
@@ -122,6 +123,7 @@ vnc[HOSTNAME]="$(hostname -s)"
 vnc[ACCESS_HOST]="${access_host}"
 vnc[WEBSOCKET]="${websocket}"
 vnc[TYPE]="${sessiontype}"
+vnc[VPN_ADDRESS]="${vpn_address}"
 EOF
     chmod 0600 "${metadata_file}"
 }

--- a/clusterware-sessions/lib/functions/vnc.functions.sh
+++ b/clusterware-sessions/lib/functions/vnc.functions.sh
@@ -19,6 +19,11 @@
 # For more information on the Alces Clusterware, please visit:
 # https://github.com/alces-software/clusterware
 #==============================================================================
+#ALCES_META
+# Refer to `clusterware/scripts/development/propagate`.
+#path=/opt/clusterware/lib/functions/vnc.functions.sh
+#ALCES_META_END
+
 require xdg
 require repo
 require files

--- a/clusterware-sessions/libexec/session/actions/info
+++ b/clusterware-sessions/libexec/session/actions/info
@@ -45,10 +45,17 @@ main() {
             else
                 . "${sessiondir}"/metadata.vars.sh
                 host="Host address: ${vnc[ACCESS_HOST]}"
+
                 if [ "${vnc[ACCESS_HOST]}" != "${vnc[HOST]}" ]; then
                     host="$host
 Service host: ${vnc[HOST]}"
                 fi
+
+                if [ -n "${vnc[VPN_ADDRESS]}" ]; then
+                    host="$host
+VPN address:  ${vnc[VPN_ADDRESS]}"
+                fi
+
                 cat <<EOF
 Identity:     ${sessionid}
 Type:         ${vnc[TYPE]}

--- a/clusterware-sessions/libexec/session/actions/info
+++ b/clusterware-sessions/libexec/session/actions/info
@@ -20,6 +20,11 @@
 # For more information on the Alces Clusterware, please visit:
 # https://github.com/alces-software/clusterware
 #==============================================================================
+#ALCES_META
+# Refer to `clusterware/scripts/development/propagate`.
+#path=/opt/clusterware/libexec/session/actions/info
+#ALCES_META_END
+
 require action
 require vnc
 

--- a/clusterware-sessions/libexec/session/actions/start
+++ b/clusterware-sessions/libexec/session/actions/start
@@ -20,6 +20,11 @@
 # For more information on the Alces Clusterware, please visit:
 # https://github.com/alces-software/clusterware
 #==============================================================================
+#ALCES_META
+# Refer to `clusterware/scripts/development/propagate`.
+#path=/opt/clusterware/libexec/session/actions/start
+#ALCES_META_END
+
 require action
 require files
 require network

--- a/clusterware-sessions/libexec/session/actions/start
+++ b/clusterware-sessions/libexec/session/actions/start
@@ -209,7 +209,16 @@ EOF
         action_die "VNC server did not start successfully, unable to locate process file."
     fi
 
-    sessionvars=("${_SESSIONID}" "${host_address}" "${access_address}" "${vnc[DISPLAY]}" "${password}" "${vnc[WEBSOCKET]}" "${sessiontype}" "${vpn_address}")
+    sessionvars=("${_SESSIONID}" \
+        "${host_address}" \
+        "${access_address}" \
+    "${vnc[DISPLAY]}" \
+    "${password}" \
+    "${vnc[WEBSOCKET]}" \
+    "${sessiontype}" \
+    "${vpn_address}" \
+    )
+
     vnc_write_detail_file "${sessionvars[@]}"
     vnc_write_vars_file "${sessionvars[@]}"
     if [ "$terse" ]; then

--- a/clusterware-sessions/libexec/session/actions/start
+++ b/clusterware-sessions/libexec/session/actions/start
@@ -200,6 +200,8 @@ EOF
 
     host_address=$(network_get_public_address)
     access_address=$(network_get_mapped_address "${host_address}" table access)
+    vpn_address="$(network_get_iface_address tun0 2> /dev/null)"
+
     vnc[WEBSOCKET]=$(network_get_free_port 41361)
     _start_websocket "$host_address" "${vnc[WEBSOCKET]}" "$((5900+${_VNC_DISPLAY}))"
 
@@ -207,7 +209,7 @@ EOF
         action_die "VNC server did not start successfully, unable to locate process file."
     fi
 
-    sessionvars=("${_SESSIONID}" "${host_address}" "${access_address}" "${vnc[DISPLAY]}" "${password}" "${vnc[WEBSOCKET]}" "${sessiontype}")
+    sessionvars=("${_SESSIONID}" "${host_address}" "${access_address}" "${vnc[DISPLAY]}" "${password}" "${vnc[WEBSOCKET]}" "${sessiontype}" "${vpn_address}")
     vnc_write_detail_file "${sessionvars[@]}"
     vnc_write_vars_file "${sessionvars[@]}"
     if [ "$terse" ]; then


### PR DESCRIPTION
This PR includes the IP address of the node on the cluster VPN in the output of `alces session start`, as requested in https://github.com/alces-software/clusterware-services/issues/29, in addition to also showing the 'access host IP'.

I've tried to do this so that the VPN method takes priority, if present, and it's also clear when a method requires VPN access and is secure by default, or the reverse.

I've also added the VPN address to the `alces session info` output as it seemed to fit here.