### PR TITLE
Support multiple autoscaling groups in SGE

### DIFF
--- a/gridscheduler/gridscheduler.functions.sh
+++ b/gridscheduler/gridscheduler.functions.sh
@@ -46,16 +46,15 @@ gridscheduler_enable_node() {
 }
 
 gridscheduler_parse_job_states() {
-    local tgtfile cores_per_node queue_wildcard
+    local tgtfile cores_per_node
     tgtfile="$1"
     cores_per_node="$2"
-    queue_wildcard="${3:-*}"
     require ruby
     gridscheduler_setup_environment
     ruby_run <<RUBY > "${tgtfile}"
 require 'rexml/document'
-pending_job_ids = IO.popen("qstat -u '*' -s p -q '$queue_wildcard' | tail -n+3 | awk '{print \$1;}'").read.split("\n")
-running_job_ids = IO.popen("qstat -u '*' -s r -q '$queue_wildcard' | tail -n+3 | awk '{print \$1;}'").read.split("\n")
+pending_job_ids = IO.popen("qstat -u '*' -s p | tail -n+3 | awk '{print \$1;}'").read.split("\n")
+running_job_ids = IO.popen("qstat -u '*' -s r | tail -n+3 | awk '{print \$1;}'").read.split("\n")
 nodes = 0.0
 cores = 0
 cores_per_node = ${cores_per_node:-2}

--- a/gridscheduler/gridscheduler.functions.sh
+++ b/gridscheduler/gridscheduler.functions.sh
@@ -15,17 +15,16 @@ gridscheduler_setup_environment() {
 }
 
 gridscheduler_empty_nodes() {
-    require ruby
-    gridscheduler_setup_environment
-    ruby_run <<RUBY
+  require ruby
+  gridscheduler_setup_environment
+  ruby_run <<RUBY
 require 'rexml/document'
-doc = REXML::Document.new(IO.popen('qstat -f -xml -q bynode.q@*'))
-doc.each_element('//Queue-List') do |el|
-  used = el.text('slots_used')
-  name = el.text('name')
-  state = el.text('state')
-  if state != 'S' && used == "0"
-    puts name.split('@').last.split('.').first
+doc = REXML::Document.new(IO.popen('qhost -j -xml'))
+doc.each_element('//host') do |el|
+  name = el.attribute('name')
+  jobs = el.get_elements('job')
+  if jobs.empty?
+    puts name
   end
 end
 RUBY

--- a/gridscheduler/gridscheduler.functions.sh
+++ b/gridscheduler/gridscheduler.functions.sh
@@ -67,7 +67,10 @@ autoscaling_queues.each do |q|
   specified_queue_nodes[q] = { :nodes => 0.0, :cores => 0 }
 end
 
-pending_job_ids.each do |jid|
+# In order to get a value for "total required size of autoscaling group" we need
+# to consider _both_ pending and running jobs.
+
+(running_job_ids + pending_job_ids).each do |jid|
   doc = REXML::Document.new(IO.popen("qstat -xml -j #{jid}"))
   slots = (doc.text('//JB_pe_range/ranges/RN_max') || 1).to_i
   pe = doc.text('//JB_pe')

--- a/gridscheduler/gridscheduler.functions.sh
+++ b/gridscheduler/gridscheduler.functions.sh
@@ -123,8 +123,8 @@ if !specified_queue_nodes.empty?
 end
 
 specified_queue_nodes.each do |k,v|
-  puts "gridscheduler_queue_#{k.gsub("-", "_")}_cores_req=#{v[:cores]}"
-  puts "gridscheduler_queue_#{k.gsub("-", "_")}_nodes_req=#{v[:nodes].ceil}"
+  puts "gridscheduler_queue_#{k.gsub(/[-\.]/, "_")}_cores_req=#{v[:cores]}"
+  puts "gridscheduler_queue_#{k.gsub(/[-\.]/, "_")}_nodes_req=#{v[:nodes].ceil}"
 end
 RUBY
 }

--- a/gridscheduler/gridscheduler.functions.sh
+++ b/gridscheduler/gridscheduler.functions.sh
@@ -111,6 +111,13 @@ results.each do |k,v|
   puts "#{k}=#{v}"
 end
 
+# Add any non-queue-specific demand arbitrarily to the first queue if we have one
+# Much easier to do it in here than in Bash!
+if specified_queue_nodes.first
+  specified_queue_nodes.first[:nodes] += nodes.ceil
+  specified_queue_nodes.first[:cores] += cores
+end
+
 specified_queue_nodes.each do |k,v|
   puts "gridscheduler_queue_#{k}_cores_req=#{v[:cores]}"
   puts "gridscheduler_queue_#{k}_nodes_req=#{v[:nodes].ceil}"

--- a/gridscheduler/gridscheduler.functions.sh
+++ b/gridscheduler/gridscheduler.functions.sh
@@ -119,7 +119,7 @@ end
 if !specified_queue_nodes.empty?
   k = specified_queue_nodes.keys.first
   specified_queue_nodes[k][:nodes] += nodes.ceil
-  specified_queue_nodes[k]][:cores] += cores
+  specified_queue_nodes[k][:cores] += cores
 end
 
 specified_queue_nodes.each do |k,v|

--- a/gridscheduler/gridscheduler.functions.sh
+++ b/gridscheduler/gridscheduler.functions.sh
@@ -116,9 +116,10 @@ end
 
 # Add any non-queue-specific demand arbitrarily to the first queue if we have one
 # Much easier to do it in here than in Bash!
-if specified_queue_nodes.first
-  specified_queue_nodes.first[:nodes] += nodes.ceil
-  specified_queue_nodes.first[:cores] += cores
+if !specified_queue_nodes.empty?
+  k = specified_queue_nodes.keys.first
+  specified_queue_nodes[k][:nodes] += nodes.ceil
+  specified_queue_nodes[k]][:cores] += cores
 end
 
 specified_queue_nodes.each do |k,v|

--- a/gridscheduler/gridscheduler.functions.sh
+++ b/gridscheduler/gridscheduler.functions.sh
@@ -46,15 +46,16 @@ gridscheduler_enable_node() {
 }
 
 gridscheduler_parse_job_states() {
-    local tgtfile cores_per_node
+    local tgtfile cores_per_node queue_wildcard
     tgtfile="$1"
     cores_per_node="$2"
+    queue_wildcard="${3:-*}"
     require ruby
     gridscheduler_setup_environment
     ruby_run <<RUBY > "${tgtfile}"
 require 'rexml/document'
-pending_job_ids = IO.popen("qstat -u '*' -s p | tail -n+3 | awk '{print \$1;}'").read.split("\n")
-running_job_ids = IO.popen("qstat -u '*' -s r | tail -n+3 | awk '{print \$1;}'").read.split("\n")
+pending_job_ids = IO.popen("qstat -u '*' -s p -q '$queue_wildcard' | tail -n+3 | awk '{print \$1;}'").read.split("\n")
+running_job_ids = IO.popen("qstat -u '*' -s r -q '$queue_wildcard' | tail -n+3 | awk '{print \$1;}'").read.split("\n")
 nodes = 0.0
 cores = 0
 cores_per_node = ${cores_per_node:-2}

--- a/gridscheduler/gridscheduler.functions.sh
+++ b/gridscheduler/gridscheduler.functions.sh
@@ -23,7 +23,7 @@ doc = REXML::Document.new(IO.popen('qhost -j -xml'))
 doc.each_element('//host') do |el|
   name = el.attribute('name')
   jobs = el.get_elements('job')
-  if jobs.empty?
+  if jobs.empty? and name != "global"
     puts name
   end
 end

--- a/gridscheduler/gridscheduler.functions.sh
+++ b/gridscheduler/gridscheduler.functions.sh
@@ -123,8 +123,8 @@ if !specified_queue_nodes.empty?
 end
 
 specified_queue_nodes.each do |k,v|
-  puts "gridscheduler_queue_#{k}_cores_req=#{v[:cores]}"
-  puts "gridscheduler_queue_#{k}_nodes_req=#{v[:nodes].ceil}"
+  puts "gridscheduler_queue_#{k.gsub("-", "_")}_cores_req=#{v[:cores]}"
+  puts "gridscheduler_queue_#{k.gsub("-", "_")}_nodes_req=#{v[:nodes].ceil}"
 end
 RUBY
 }

--- a/gridscheduler/gridscheduler.functions.sh
+++ b/gridscheduler/gridscheduler.functions.sh
@@ -21,7 +21,7 @@ gridscheduler_empty_nodes() {
 require 'rexml/document'
 doc = REXML::Document.new(IO.popen('qhost -j -xml'))
 doc.each_element('//host') do |el|
-  name = el.attribute('name')
+  name = el.attribute('name').value
   jobs = el.get_elements('job')
   if jobs.empty? and name != "global"
     puts name


### PR DESCRIPTION
This PR alters some of the SGE functionality within Clusterware to support the changes made in https://github.com/alces-software/clusterware-handlers/pull/60 for multiple autoscaling groups in a cluster.

In particular:
- Empty nodes are determined by examining the output of `qhost` rather than examining `bynode.q`; hosts with no jobs running are returned as empty (excluding `global`).
- The `parse_job_states` function now generates `cores_req` and `nodes_req` variables for each autoscaling queue, in addition to the overall ones generated previously. Any pending jobs that have not specified a queue to run in will be arbitrarily counted towards the first autoscaling queue (in addition to the overall figure).

Related PRs:
- `clusterware-handlers`: https://github.com/alces-software/clusterware-handlers/pull/60
- `flight-hangar-db`: https://github.com/alces-software/flight-hangar-db/pull/2