### PR TITLE
Support multiple autoscaling groups in Slurm

### DIFF
--- a/gridscheduler/gridscheduler.functions.sh
+++ b/gridscheduler/gridscheduler.functions.sh
@@ -63,7 +63,7 @@ cores_per_node = ${cores_per_node:-2}
 
 specified_queue_nodes = {}
 autoscaling_queues.each do |q|
-  specified_queue_nodes[q] = { :nodes => 0.0, :cores => 0 }
+  specified_queue_nodes[q.gsub(/_by(slot|node)_q/, "")] = { :nodes => 0.0, :cores => 0 }
 end
 
 # In order to get a value for "total required size of autoscaling group" we need
@@ -80,12 +80,13 @@ end
   if specific_queue
     autoscaling_queues.each do |q|
       if File.fnmatch(specific_queue, q)
+        groupname = q.gsub(/_by(slot|node)_q/, "")
         if pe == "mpinodes" || pe == "mpinodes-verbose"
-          specified_queue_nodes[q][:nodes] += slots
-          specified_queue_nodes[q][:cores] += (cores_per_node * slots)
+          specified_queue_nodes[groupname][:nodes] += slots
+          specified_queue_nodes[groupname][:cores] += (cores_per_node * slots)
         else
-          specified_queue_nodes[q][:cores] += (slots || 1)
-          specified_queue_nodes[q][:nodes] += ((slots || 1) * 1.0 / cores_per_node)
+          specified_queue_nodes[groupname][:cores] += (slots || 1)
+          specified_queue_nodes[groupname][:nodes] += ((slots || 1) * 1.0 / cores_per_node)
         end
         counted = true
         break

--- a/slurm/slurm.functions.sh
+++ b/slurm/slurm.functions.sh
@@ -40,7 +40,7 @@ slurm_parse_job_states() {
     require ruby
     slurm_setup_environment
     ruby_run <<RUBY > "${tgtfile}"
-r = IO.popen("squeue -O state,numcpus,numnodes | tail -n+2").read.split("\n").map do |l|
+r = IO.popen("squeue -O state,numcpus,numnodes -h").read.split("\n").map do |l|
   {}.tap do |h|
     vals = l.split(/\s+/)
     h[:state], h[:cores], h[:nodes] = vals

--- a/slurm/slurm.functions.sh
+++ b/slurm/slurm.functions.sh
@@ -64,6 +64,48 @@ results = {
   end.ceil
 }
 results.each { |k,v| puts "#{k}=#{v}" }
+
+# Now consider autoscaling groups (== (partitions - "all"))
+
+groups = IO.popen("sinfo -h -o '%R'").read.split("\n")
+
+group_results = {}
+
+groups.each { |group|
+
+  group_jobs = IO.popen("squeue -O state,numcpus,numnodes -h -p #{group}").read.split("\n").map do |l|
+    {}.tap do |h|
+      vals = l.split(/\s+/)
+      h[:state], h[:cores], h[:nodes] = vals
+    end
+  end.select { |o| o[:state] == "PENDING" || o[:state] == "RUNNING" }
+
+  group_results[group] = {
+    :cores_req => group_jobs.reduce(0) { |memo, o| memo + o[:cores].to_i },
+    :nodes_req => group_jobs.reduce(0.0) do |memo, o|
+     if (o[:cores].to_f / cores_per_node).ceil < o[:nodes].to_i
+       memo + o[:nodes].to_i
+     else
+       memo + o[:cores].to_f / cores_per_node
+     end
+    end.ceil
+  }
+}
+
+all_partition = group_results.delete("all")
+if all_partition
+  # Jobs outside a specific scaling group (e.g. in 'all') we arbitrarily add to
+  # the first of the autoscaling groups
+  first_autoscaling_group = groups.reject { |g| g == "all" }.first
+  group_results[first_autoscaling_group][:cores_req] += all_partition[:cores_req]
+  group_results[first_autoscaling_group][:nodes_req] += all_partition[:nodes_req]
+end
+
+group_results.each do |k,v|
+  puts "slurm_queue_#{k.gsub(/[-\.]/, "_")}_cores_req=#{v[:cores_req]}"
+  puts "slurm_queue_#{k.gsub(/[-\.]/, "_")}_nodes_req=#{v[:nodes_req]}"
+end
+
 RUBY
 }
 


### PR DESCRIPTION
This PR adds support for multiple autoscaling groups using the Slurm scheduler, in support of https://github.com/alces-software/clusterware-handlers/pull/62. Slurm now reports per-autoscaling-group demand as well as overall demand.

To support changes made in that other PR, this also changes how SGE loads are reported - amalgamating `byslot` and `bynode` demand figures and thus abstracting these SGE-specific concepts.

Related PR: https://github.com/alces-software/clusterware-handlers/pull/62