### PR TITLE
Enhancements to multiple autoscaling group support

### DIFF
--- a/gridscheduler/gridscheduler.functions.sh
+++ b/gridscheduler/gridscheduler.functions.sh
@@ -56,7 +56,7 @@ require 'rexml/document'
 pending_job_ids = IO.popen("qstat -u '*' -s p | tail -n+3 | awk '{print \$1;}'").read.split("\n")
 running_job_ids = IO.popen("qstat -u '*' -s r | tail -n+3 | awk '{print \$1;}'").read.split("\n")
 
-autoscaling_groups = Dir.entries("${cw_ROOT}/etc/config/autoscaling/groups").select { |e| !File.directory?(e) }
+autoscaling_groups = Dir.entries("${cw_ROOT}/etc/config/autoscaling/by_label").select { |e| !File.directory?(e) }
 
 nodes = 0.0
 cores = 0

--- a/gridscheduler/gridscheduler.functions.sh
+++ b/gridscheduler/gridscheduler.functions.sh
@@ -56,7 +56,7 @@ require 'rexml/document'
 pending_job_ids = IO.popen("qstat -u '*' -s p | tail -n+3 | awk '{print \$1;}'").read.split("\n")
 running_job_ids = IO.popen("qstat -u '*' -s r | tail -n+3 | awk '{print \$1;}'").read.split("\n")
 
-autoscaling_groups = Dir.entries("${cw_ROOT}/etc/config/autoscaling/by_label").select { |e| !File.directory?(e) }
+autoscaling_groups = Dir.entries("${cw_ROOT}/etc/config/autoscaling/by-label").select { |e| !File.directory?(e) }
 
 nodes = 0.0
 cores = 0

--- a/gridscheduler/gridscheduler.functions.sh
+++ b/gridscheduler/gridscheduler.functions.sh
@@ -56,7 +56,7 @@ require 'rexml/document'
 pending_job_ids = IO.popen("qstat -u '*' -s p | tail -n+3 | awk '{print \$1;}'").read.split("\n")
 running_job_ids = IO.popen("qstat -u '*' -s r | tail -n+3 | awk '{print \$1;}'").read.split("\n")
 
-autoscaling_groups = Dir.entries("${cw_ROOT}/etc/config/autoscaling").select { |e| !File.directory?(e) }.reject { |e| e == "default" }
+autoscaling_groups = Dir.entries("${cw_ROOT}/etc/config/autoscaling/groups").select { |e| !File.directory?(e) }
 
 nodes = 0.0
 cores = 0

--- a/gridscheduler/gridscheduler.functions.sh
+++ b/gridscheduler/gridscheduler.functions.sh
@@ -56,15 +56,15 @@ pending_job_ids = IO.popen("qstat -u '*' -s p | tail -n+3 | awk '{print \$1;}'")
 running_job_ids = IO.popen("qstat -u '*' -s r | tail -n+3 | awk '{print \$1;}'").read.split("\n")
 
 autoscaling_queues = IO.popen("qconf -sql | grep FlightComputeGroup").read.split("\n")
-autoscaling_groups = autoscaling_queues.map { |q| q.gsub(/_by(slot|node)_q/, "") }.uniq
+autoscaling_groups = autoscaling_queues.map { |q| q.gsub(/.by(slot|node).q/, "") }.uniq
 
 nodes = 0.0
 cores = 0
 cores_per_node = ${cores_per_node:-2}
 
 specified_queue_nodes = {}
-autoscaling_queues.each do |q|
-  specified_queue_nodes[q.gsub(/_by(slot|node)_q/, "")] = { :nodes => 0.0, :cores => 0 }
+autoscaling_groups.each do |q|
+  specified_queue_nodes[q] = { :nodes => 0.0, :cores => 0 }
 end
 
 # In order to get a value for "total required size of autoscaling group" we need

--- a/gridscheduler/gridscheduler.functions.sh
+++ b/gridscheduler/gridscheduler.functions.sh
@@ -50,6 +50,7 @@ gridscheduler_parse_job_states() {
     cores_per_node="$2"
     require ruby
     gridscheduler_setup_environment
+
     ruby_run <<RUBY > "${tgtfile}"
 require 'rexml/document'
 pending_job_ids = IO.popen("qstat -u '*' -s p | tail -n+3 | awk '{print \$1;}'").read.split("\n")
@@ -133,10 +134,9 @@ end
 
 # Add any non-queue-specific demand arbitrarily to the first queue if we have one
 # Much easier to do it in here than in Bash!
-if !specified_queue_nodes.empty?
-  k = specified_queue_nodes.keys.first
-  specified_queue_nodes[k][:nodes] += nodes.ceil
-  specified_queue_nodes[k][:cores] += cores
+if !specified_queue_nodes.empty? and !"$default_queue".empty?
+  specified_queue_nodes["$default_queue"][:nodes] += nodes.ceil
+  specified_queue_nodes["$default_queue"][:cores] += cores
 end
 
 specified_queue_nodes.each do |k,v|

--- a/openlava/openlava.functions.sh
+++ b/openlava/openlava.functions.sh
@@ -51,7 +51,8 @@ results = {
   "openlava_job_run" => running_jobs,
   "openlava_job_total" => jobs.length,
   "openlava_cores_req" => cores_req,
-  "openlava_nodes_req" => ((cores_req * 1.0) / cores_per_node).ceil
+  "openlava_nodes_req" => ((cores_req * 1.0) / cores_per_node).ceil,
+  "openlava_queue_${default_queue}_nodes_req" => ((cores_req * 1.0) / cores_per_node).ceil,
 }
 results.each { |k,v| puts "#{k}=#{v}" }
 RUBY

--- a/pbspro/pbspro.functions.sh
+++ b/pbspro/pbspro.functions.sh
@@ -51,7 +51,8 @@ results = {
   "pbspro_job_run" => running_job_count,
   "pbspro_job_total" => running_job_count + pending_jobs.length,
   "pbspro_cores_req" => cores_req,
-  "pbspro_nodes_req" => nodes_req
+  "pbspro_nodes_req" => nodes_req,
+  "pbspro_queue_${default_queue}_nodes_req" => nodes_req
 }
 results.each { |k,v| puts "#{k}=#{v}" }
 RUBY

--- a/slurm/slurm.functions.sh
+++ b/slurm/slurm.functions.sh
@@ -93,12 +93,11 @@ groups.each { |group|
 }
 
 all_partition = group_results.delete("all")
-if all_partition
-  # Jobs outside a specific scaling group (e.g. in 'all') we arbitrarily add to
-  # the first of the autoscaling groups
-  first_autoscaling_group = groups.reject { |g| g == "all" }.first
-  group_results[first_autoscaling_group][:cores_req] += all_partition[:cores_req]
-  group_results[first_autoscaling_group][:nodes_req] += all_partition[:nodes_req]
+if all_partition and !"$default_queue".empty?
+  # Jobs outside a specific scaling group (e.g. in 'all') we add to the default
+  # autoscaling group
+  group_results["$default_queue"][:cores_req] += all_partition[:cores_req]
+  group_results["$default_queue"][:nodes_req] += all_partition[:nodes_req]
 end
 
 group_results.each do |k,v|

--- a/torque/torque.functions.sh
+++ b/torque/torque.functions.sh
@@ -51,7 +51,8 @@ results = {
   "torque_job_run" => running_job_count,
   "torque_job_total" => running_job_count + pending_jobs.length,
   "torque_cores_req" => cores_req,
-  "torque_nodes_req" => nodes_req
+  "torque_nodes_req" => nodes_req,
+  "torque_queue_${default_queue}_nodes_req" => nodes_req
 }
 results.each { |k,v| puts "#{k}=#{v}" }
 RUBY


### PR DESCRIPTION
This PR enhances SGE support for multiple autoscaling groups, plus adds preliminary support to our other schedulers.

- Autoscaling-group-backed parallel environments are now also considered when calculating group loads.
- Autoscaling group labels are used for iteration over groups.
- Load not specifically assigned to a group is placed in the `$default_queue` group. The value of that environment variable is set by the calling code in `clusterware_handlers/autoscaling/share/autoscaler#_scale_out()`.
- Slurm also now uses the `$default_queue` value for generic loads.

OpenLava, PBSPro and Torque support has been updated to continue working with a single autoscaling queue - in all cases the default queue is used.

Related PRs:
- `clusterware-handlers`: https://github.com/alces-software/clusterware-handlers/pull/64
- `flight-hangar-db`: https://github.com/alces-software/flight-hangar-db/pull/3