### PR TITLE
Feature/misc improvements to job queues

### DIFF
--- a/clusterware-customize/lib/functions/job-queue.functions.sh
+++ b/clusterware-customize/lib/functions/job-queue.functions.sh
@@ -109,6 +109,7 @@ job_queue_save_job_output() {
     # about python-magic not being available.
 
     "${cw_ROOT}"/opt/s3cmd/s3cmd put --recursive \
+        --acl-public \
         --default-mime-type=text/plain \
         --guess-mime-type \
         --no-mime-magic \

--- a/clusterware-customize/lib/functions/job-queue.functions.sh
+++ b/clusterware-customize/lib/functions/job-queue.functions.sh
@@ -114,6 +114,11 @@ job_queue_save_job_output() {
         --no-mime-magic \
         $(job_queue_work_dir_path "${queue}" "${output_dir}"/"${job_id}"/"$(hostname)") \
         $(job_queue_bucket_path "${queue}" "${output_dir}"/"${job_id}")/
+
+    mkdir -p /var/log/clusterware/prime-continuous-delivery/
+    rsync -a $(job_queue_work_dir_path "${queue}" "${output_dir}"/) \
+        /var/log/clusterware/prime-continuous-delivery/"${output_dir}"/
+
 }
 
 # If there are any objects already stored with job_id, the job is invalid.  We

--- a/clusterware-customize/lib/functions/job-queue.functions.sh
+++ b/clusterware-customize/lib/functions/job-queue.functions.sh
@@ -98,7 +98,20 @@ job_queue_save_job_output() {
     job_id=$2
     output_dir=$3
 
-    "${cw_ROOT}"/opt/s3cmd/s3cmd put --quiet --recursive \
+    # python-magic isn't installed on our clusters by default and without it
+    # the results files are uploaded as binary/octet-stream, which breaks
+    # viewing the logs in a browser tab.
+    #
+    # Most of the files should be text/plain, so we use that as the default
+    # and try to get s3cmd to use the file extension for guessing others.
+    #
+    # Using `--no-mime-magic` prevents the logs from filling with warnings
+    # about python-magic not being available.
+
+    "${cw_ROOT}"/opt/s3cmd/s3cmd put --recursive \
+        --default-mime-type=text/plain \
+        --guess-mime-type \
+        --no-mime-magic \
         $(job_queue_work_dir_path "${queue}" "${output_dir}"/"${job_id}"/"$(hostname)") \
         $(job_queue_bucket_path "${queue}" "${output_dir}"/"${job_id}")/
 }

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/get-output
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/get-output
@@ -22,6 +22,7 @@
 #==============================================================================
 require action
 require handler
+require process
 require job-queue
 
 main() {
@@ -37,4 +38,5 @@ main() {
     job_queue_get_output_file "${queue}" "${job_id}" "${output_file}"
 }
 
+process_reexec_sudo "$@"
 main "$@"

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/list-jobs
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/list-jobs
@@ -22,6 +22,7 @@
 #==============================================================================
 require action
 require handler
+require process
 require job-queue
 
 main() {
@@ -35,4 +36,5 @@ main() {
     job_queue_list_jobs_in_queue "${queue}" "pending"
 }
 
+process_reexec_sudo "$@"
 main "$@"

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/list-output
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/list-output
@@ -22,6 +22,7 @@
 #==============================================================================
 require action
 require handler
+require process
 require job-queue
 
 main() {
@@ -36,4 +37,5 @@ main() {
     job_queue_list_output_files "${queue}" "${job_id}"
 }
 
+process_reexec_sudo "$@"
 main "$@"

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/list-queues
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/list-queues
@@ -22,6 +22,8 @@
 #==============================================================================
 require action
 require handler
+require process
 require job-queue
 
+process_reexec_sudo "$@"
 job_queue_list_queues "$@"

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/put
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/put
@@ -22,6 +22,7 @@
 #==============================================================================
 require action
 require handler
+require process
 require job-queue
 
 main() {
@@ -44,4 +45,5 @@ main() {
     echo "${job_id}"
 }
 
+process_reexec_sudo "$@"
 main "$@"

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/rm
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/rm
@@ -22,6 +22,7 @@
 #==============================================================================
 require action
 require handler
+require process
 require job-queue
 
 main() {
@@ -36,4 +37,5 @@ main() {
     job_queue_delete_job "${queue}" "${job_id}"
 }
 
+process_reexec_sudo "$@"
 main "$@"

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/status
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/status
@@ -22,6 +22,7 @@
 #==============================================================================
 require action
 require handler
+require process
 require job-queue
 
 main() {
@@ -36,4 +37,5 @@ main() {
     job_queue_get_job_status "${queue}" "${job_id}"
 }
 
+process_reexec_sudo "$@"
 main "$@"


### PR DESCRIPTION
 - Allow job-queue functionality to be run via sudo.
 - Silence the Module python-magic is not available... warning.
 - Store a copy of the logs locally.
 - Upload the files with the correct mime-types.
 - Upload the files to be publicly readable.