### PR TITLE
Customizer service and enhancements

### DIFF
--- a/clusterware-customize/lib/functions/customize-repository-file.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository-file.functions.sh
@@ -37,3 +37,11 @@ customize_repository_file_install() {
 
   cp -r "${repo_url}/${profile_name}" "${target}"
 }
+
+customize_repository_file_push() {
+  local dest src
+  dest="$1"
+  src="$2"
+
+  cp -r "$src" "$dest"
+}

--- a/clusterware-customize/lib/functions/customize-repository-file.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository-file.functions.sh
@@ -25,4 +25,5 @@ customize_repository_file_index() {
   local url
   url="$1"
   cat "${url}/index.yml"
+  return $?
 }

--- a/clusterware-customize/lib/functions/customize-repository-file.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository-file.functions.sh
@@ -45,3 +45,11 @@ customize_repository_file_push() {
 
   cp -r "$src" "$dest"
 }
+
+customize_repository_file_set_index() {
+  local repo_url src
+  repo_url="$1"
+  src="$2"
+
+  cp "$src" "$repo_url"/index.yml
+}

--- a/clusterware-customize/lib/functions/customize-repository-file.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository-file.functions.sh
@@ -27,3 +27,13 @@ customize_repository_file_index() {
   cat "${url}/index.yml"
   return $?
 }
+
+customize_repository_file_install() {
+  local repo_name repo_url profile_name target
+  repo_name="$1"
+  repo_url="$2"
+  profile_name="$3"
+  target="$4"
+
+  cp -r "${repo_url}/${profile_name}" "${target}"
+}

--- a/clusterware-customize/lib/functions/customize-repository-file.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository-file.functions.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+
+customize_repository_file_index() {
+  local url
+  url="$1"
+  cat "${url}/index.yml"
+}

--- a/clusterware-customize/lib/functions/customize-repository-http.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository-http.functions.sh
@@ -53,3 +53,8 @@ customize_repository_http_install() {
       return 1
   fi
 }
+
+customize_repository_http_push() {
+  echo "Unable to push to an HTTP repository."
+  return 1
+}

--- a/clusterware-customize/lib/functions/customize-repository-http.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository-http.functions.sh
@@ -58,3 +58,8 @@ customize_repository_http_push() {
   echo "Unable to push to an HTTP repository."
   return 1
 }
+
+customize_repository_http_set_index() {
+  echo "Unable to set index for an HTTP repository."
+  return 1
+}

--- a/clusterware-customize/lib/functions/customize-repository-http.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository-http.functions.sh
@@ -27,3 +27,29 @@ customize_repository_http_index() {
   curl -s -f "${url}/index.yml"
   return $?
 }
+
+customize_repository_http_install() {
+  local manifest profile_name repo_name repo_url target
+  repo_name="$1"
+  repo_url="$2"
+  profile_name="$3"
+  target="$4"
+
+  manifest=$(curl -s -f "${repo_url}/${profile_name}/manifest.txt")
+
+  if [ "${manifest}" ] && ! echo "${manifest[*]}" | grep -q '<Error>'; then
+      # fetch each file within manifest file
+      for f in ${manifest}; do
+          mkdir -p "${target}/$(dirname "$f")"
+          if curl -s -f -o ${target}/${f} "${repo_url}/${profile_name}/${f}"; then
+              echo "Fetched: ${f}"
+          else
+              echo "Unable to fetch: ${f}"
+              return 1
+          fi
+      done
+  else
+      echo "No manifest found for ${repo_name}/${profile_name}"
+      return 1
+  fi
+}

--- a/clusterware-customize/lib/functions/customize-repository-http.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository-http.functions.sh
@@ -25,4 +25,5 @@ customize_repository_http_index() {
   local url
   url="$1"
   curl -s -f "${url}/index.yml"
+  return $?
 }

--- a/clusterware-customize/lib/functions/customize-repository-http.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository-http.functions.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+
+customize_repository_http_index() {
+  local url
+  url="$1"
+  curl -s -f "${url}/index.yml"
+}

--- a/clusterware-customize/lib/functions/customize-repository-s3.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository-s3.functions.sh
@@ -67,7 +67,7 @@ customize_repository_s3_index() {
 }
 
 customize_repository_s3_install() {
-  local host profile_name repo_name repo_url target
+  local host profile_name repo_name retval repo_url target
   repo_name="$1"
   repo_url="$2"
   profile_name="$3"
@@ -76,11 +76,8 @@ customize_repository_s3_install() {
   _set_s3_config
 
   if [ "${s3cfg}" ]; then
-    $S3CMD get "${repo_url}/${profile_name}" "${target}"
-    if rmdir "${target}" 2>/dev/null; then
-        echo "No profile found for: ${repo_name}/${profile_name}"
-        return 1
-    fi
+    $S3CMD get --force -r "${repo_url}/${profile_name}/" "${target}"
+    retval="$?"
   else
     require customize-repository-http
     echo "Falling back to HTTP installation as S3 configuration unavailable."
@@ -92,6 +89,8 @@ customize_repository_s3_install() {
     fi
 
     customize_repository_http_install "$repo_name" "https://${host}/${repo_url##s3://}" "$profile_name" "$target"
+    retval="$?"
   fi
   _clear_s3_config
+  return $retval
 }

--- a/clusterware-customize/lib/functions/customize-repository-s3.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository-s3.functions.sh
@@ -59,7 +59,7 @@ customize_repository_s3_index() {
   url="$1"
   _set_s3_config
 
-  $S3CMD get "$url" -
+  $S3CMD get "$url/index.yml" -
 
   _clear_s3_config
 }

--- a/clusterware-customize/lib/functions/customize-repository-s3.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository-s3.functions.sh
@@ -65,3 +65,33 @@ customize_repository_s3_index() {
   _clear_s3_config
   return $retval
 }
+
+customize_repository_s3_install() {
+  local host profile_name repo_name repo_url target
+  repo_name="$1"
+  repo_url="$2"
+  profile_name="$3"
+  target="$4"
+
+  _set_s3_config
+
+  if [ "${s3cfg}" ]; then
+    $S3CMD get "${repo_url}/${profile_name}" "${target}"
+    if rmdir "${target}" 2>/dev/null; then
+        echo "No profile found for: ${repo_name}/${profile_name}"
+        return 1
+    fi
+  else
+    require customize-repository-http
+    echo "Falling back to HTTP installation as S3 configuration unavailable."
+
+    if [ "${_REGION:-${cw_CLUSTER_CUSTOMIZER_region:-eu-west-1}}" == "us-east-1" ]; then
+        host=s3.amazonaws.com
+    else
+        host=s3-${_REGION:-${cw_CLUSTER_CUSTOMIZER_region:-eu-west-1}}.amazonaws.com
+    fi
+
+    customize_repository_http_install "$repo_name" "https://${host}/${repo_url##s3://}" "$profile_name" "$target"
+  fi
+  _clear_s3_config
+}

--- a/clusterware-customize/lib/functions/customize-repository-s3.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository-s3.functions.sh
@@ -36,8 +36,9 @@ _set_region() {
 
 _set_s3_config() {
   _set_region
-  s3cfg="$(mktemp /tmp/cluster-customizer.s3cfg.XXXXXXXX)"
-  cat <<EOF > "${s3cfg}"
+  if [[ "${cw_CLUSTER_CUSTOMIZER_access_key_id}" ]]; then
+    s3cfg="$(mktemp /tmp/cluster-customizer.s3cfg.XXXXXXXX)"
+    cat <<EOF > "${s3cfg}"
 [default]
 access_key = "${cw_CLUSTER_CUSTOMIZER_access_key_id}"
 secret_key = "${cw_CLUSTER_CUSTOMIZER_secret_access_key}"
@@ -45,7 +46,10 @@ security_token = ""
 use_https = True
 check_ssl_certificate = True
 EOF
-  S3CMD="${cw_ROOT}/opt/s3cmd/s3cmd -c ${s3cfg} -q"
+    S3CMD="${cw_ROOT}/opt/s3cmd/s3cmd -c ${s3cfg} -q"
+  else
+    S3CMD=false
+  fi
 }
 
 _clear_s3_config() {

--- a/clusterware-customize/lib/functions/customize-repository-s3.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository-s3.functions.sh
@@ -55,11 +55,13 @@ _clear_s3_config() {
 }
 
 customize_repository_s3_index() {
-  local url
+  local retval url
   url="$1"
   _set_s3_config
 
   $S3CMD get "$url/index.yml" -
+  retval=$?
 
   _clear_s3_config
+  return $retval
 }

--- a/clusterware-customize/lib/functions/customize-repository-s3.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository-s3.functions.sh
@@ -70,7 +70,7 @@ customize_repository_s3_index() {
     retval=$?
   else
     require customize-repository-http
-    echo "Falling back to HTTP indexing as S3 access unavailable."
+    >&2 echo "Falling back to HTTP indexing as S3 access unavailable."
 
     if [ "${_REGION:-${cw_CLUSTER_CUSTOMIZER_region:-eu-west-1}}" == "us-east-1" ]; then
         host=s3.amazonaws.com
@@ -100,7 +100,7 @@ customize_repository_s3_install() {
     retval="$?"
   else
     require customize-repository-http
-    echo "Falling back to HTTP installation as S3 access unavailable."
+    >&2 echo "Falling back to HTTP installation as S3 access unavailable."
 
     if [ "${_REGION:-${cw_CLUSTER_CUSTOMIZER_region:-eu-west-1}}" == "us-east-1" ]; then
         host=s3.amazonaws.com

--- a/clusterware-customize/lib/functions/customize-repository-s3.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository-s3.functions.sh
@@ -114,3 +114,21 @@ customize_repository_s3_install() {
   _clear_s3_config
   return $retval
 }
+
+customize_repository_s3_push() {
+  local dest retval src
+  dest="$1"
+  src="$2"
+  _set_s3_config
+
+  if [[ $src == *"/" ]]; then
+    # strip trailing slash
+    src=${src%%/}
+  fi
+
+  $S3CMD sync "$src" "$dest"
+  retval=$?
+
+  _clear_s3_config
+  return $retval
+}

--- a/clusterware-customize/lib/functions/customize-repository-s3.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository-s3.functions.sh
@@ -140,3 +140,18 @@ customize_repository_s3_push() {
   _clear_s3_config
   return $retval
 }
+
+customize_repository_s3_set_index() {
+  local index repo_url retval
+  repo_url="$1"
+  index="$2"
+
+  _set_s3_config
+
+  $S3CMD put --no-mime-magic --default-mime-type=text/plain "$index" "${repo_url}/index.yml"
+  retval=$?
+
+  _clear_s3_config
+
+  return $retval
+}

--- a/clusterware-customize/lib/functions/customize-repository-s3.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository-s3.functions.sh
@@ -121,12 +121,20 @@ customize_repository_s3_push() {
   src="$2"
   _set_s3_config
 
-  if [[ $src == *"/" ]]; then
+  if [[ "$src" == *"/" ]]; then
     # strip trailing slash
     src=${src%%/}
   fi
 
-  $S3CMD sync "$src" "$dest"
+  if [[ "$dest" != "*"/ ]]; then
+    dest="$dest/"
+  fi
+
+  $S3CMD sync --delete-removed \
+              --default-mime-type=text/plain \
+              --guess-mime-type \
+              --no-mime-magic \
+              "$src" "$dest"
   retval=$?
 
   _clear_s3_config

--- a/clusterware-customize/lib/functions/customize-repository-s3.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository-s3.functions.sh
@@ -57,7 +57,7 @@ _clear_s3_config() {
 _can_access_s3_url() {
   local url
   url="$1"
-  "$S3CMD -q ls ${url}" 2>/dev/null
+  $S3CMD ls "${url}" 2>/dev/null
 }
 
 customize_repository_s3_index() {

--- a/clusterware-customize/lib/functions/customize-repository-s3.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository-s3.functions.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+
+require files
+require network
+
+_set_region() {
+    if [ -z "${_REGION}" ]; then
+        if network_is_ec2; then
+            eval $(network_fetch_ec2_document | "${cw_ROOT}"/opt/jq/bin/jq -r '"_REGION=\(.region)"')
+        else
+            _REGION="${cw_CLUSTER_CUSTOMIZER_region:-eu-west-1}"
+        fi
+    fi
+}
+
+_set_s3_config() {
+  _set_region
+  s3cfg="$(mktemp /tmp/cluster-customizer.s3cfg.XXXXXXXX)"
+  cat <<EOF > "${s3cfg}"
+[default]
+access_key = "${cw_CLUSTER_CUSTOMIZER_access_key_id}"
+secret_key = "${cw_CLUSTER_CUSTOMIZER_secret_access_key}"
+security_token = ""
+use_https = True
+check_ssl_certificate = True
+EOF
+  S3CMD="${cw_ROOT}/opt/s3cmd/s3cmd -c ${s3cfg} -q"
+}
+
+_clear_s3_config() {
+  rm -f "${s3cfg}"
+  unset s3cfg
+  unset S3CMD
+}
+
+customize_repository_s3_index() {
+  local url
+  url="$1"
+  _set_s3_config
+
+  $S3CMD get "$url" -
+
+  _clear_s3_config
+}

--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -7,7 +7,7 @@ customize_repository_get_url() {
   name="$1"
   conffile="${2:-${cw_ROOT}/etc/cluster-customizer/config.yml}"
 
-  ruby_run <<\RUBY
+  ruby_run <<RUBY
 require 'yaml'
 repo_list = YAML.load_file("${conffile}")["repositories"]
 

--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -63,10 +63,14 @@ def bold(text)
   colorize(text, 1)
 end
 
+def installed?(profile_name)
+  File.exists?("${cw_CLUSTER_CUSTOMIZER_path}/${repo_name}-#{profile_name}")
+end
+
   manifest = YAML.load_file("${manifest_file}") || {}
 
   if manifest.key? "profiles"
-    manifest["profiles"].each do | profile_name, profile |
+    manifest["profiles"].reject {|p| installed?(p) }.each do | profile_name, profile |
       puts "${repo_name}/#{bold(profile_name)}"
     end
   end

--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -77,7 +77,7 @@ end
 def tags_to_string(tags)
   return "" if not tags
   tag_strings = []
-  tags.each { |tag|
+  tags.sort.each { |tag|
     tag_strings << colorize(tag, colour_for_tag(tag))
   }
   tag_strings.join(' ')

--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -69,7 +69,7 @@ end
 
   manifest = YAML.load_file("${manifest_file}") || {}
 
-  if manifest.key? "profiles"
+  if manifest.is_a? Hash && manifest.key? "profiles"
     manifest["profiles"].reject {|p| installed?(p) }.each do | profile_name, profile |
       puts "${repo_name}/#{bold(profile_name)}"
     end

--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -35,6 +35,10 @@ customize_repository_index() {
   local repo_name repo_url repo_type
   repo_name="$1"
   repo_url=$(customize_repository_get_url "$repo_name")
+  if [[ ! "$repo_url" ]]; then
+    echo "Unknown repository: ${repo_name}"
+    return 1
+  fi
   repo_type=$(customize_repository_type "$repo_url")
 
   require "customize-repository-${repo_type}"
@@ -94,6 +98,10 @@ customize_repository_apply() {
   profile_name="$2"
 
   repo_url=$(customize_repository_get_url "$repo_name")
+  if [[ ! "$repo_url" ]]; then
+    echo "Unknown repository: ${repo_name}"
+    return 1
+  fi
   repo_type=$(customize_repository_type "$repo_url")
 
   require "customize-repository-${repo_type}"

--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -181,11 +181,12 @@ _is_installable() {
 }
 
 customize_repository_apply() {
-  local repo_name profile_name target
+  local is_preinit repo_name profile_name target
   repo_name="$1"
   profile_name="$2"
+  is_preinit="$3"
 
-  if _is_installable "$repo_name" "$profile_name"; then
+  if _is_installable "$repo_name" "$profile_name" || [[ "$is_preinit" == "preinit" ]]; then
     repo_url=$(customize_repository_get_url "$repo_name")
     if [[ ! "$repo_url" ]]; then
       echo "Unknown repository: ${repo_name}"

--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -77,7 +77,7 @@ end
 
   manifest = YAML.load_file("${manifest_file}") || {}
 
-  if manifest.is_a? Hash && manifest.key? "profiles"
+  if manifest.is_a?(Hash) && manifest.key?("profiles")
     manifest["profiles"].select {|prn, pr| should_list?(prn, pr) }.each do | profile_name, profile |
       puts "${repo_name}/#{bold(profile_name)}"
     end

--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 require ruby
+require member
 
 _DEFAULT_CONF_FILE="${cw_ROOT}/etc/cluster-customizer/config.yml"
 
@@ -90,6 +91,21 @@ customize_repository_each() {
   for r in $repos; do
     $callback "$r"
   done
+}
+
+_run_member_hooks() {
+    local event name ip
+    members="$1"
+    event="$2"
+    shift 3
+    name="$1"
+    ip="$2"
+    if [[ -z "${members}" || ,"$members", == *,"${name}",* ]]; then
+       customize_run_hooks "${event}" \
+                           "${cw_MEMBER_DIR}"/"${name}" \
+                           "${name}" \
+                           "${ip}"
+    fi
 }
 
 customize_repository_apply() {

--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -98,7 +98,7 @@ end
   manifest = YAML.load_file("${manifest_file}") || {}
 
   if manifest.is_a?(Hash) && manifest.key?("profiles")
-    profiles = manifest["profiles"].select {|prn, pr| should_list?(prn, pr) }
+    profiles = manifest["profiles"].select {|prn, pr| should_list?(prn, pr) }.sort
     max_len = profiles.map { |pf, pp| pf.length }.max + 10
     profiles.each do | profile_name, profile |
       puts "${repo_name}/#{bold(profile_name).ljust(max_len)}#{tags_to_string(profile['tags'])}"

--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -254,17 +254,25 @@ customize_repository_push() {
     fi
     popd > /dev/null
 
+    echo "Pushing $profile_name to repository $repo_name..."
+
     customize_repository_${repo_type}_push "$repo_url" "$src"
     retval=$?
 
     if [ $retval -eq 0 ]; then
       echo "Push complete."
+      echo "Updating repository index..."
       index=$(mktemp "/tmp/cluster-customizer.repo.XXXXXXXX")
       customize_repository_${repo_type}_index "$repo_url" > "$index" 2> /dev/null
 
       customize_repository_add_to_index "$index" "$src" "$profile_name"
 
       customize_repository_${repo_type}_set_index "$repo_url" "$index"
+      if [ $? -eq 0 ]; then
+        echo "Repository index updated."
+      else
+        echo "Failed to update repository index."
+      fi
 
       rm -f "$index"
       if [[ "$tmpdir" ]]; then rm -rf "$tmpdir"; fi

--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -99,7 +99,7 @@ customize_repository_apply() {
   require "customize-repository-${repo_type}"
 
   target="${cw_CLUSTER_CUSTOMIZER_path}/${repo_name}-${profile_name}"
-  mkdir "$target"
+  mkdir -p "$target"
 
   customize_repository_${repo_type}_install "$repo_name" "$repo_url" "$profile_name" "$target"
 

--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -21,6 +21,18 @@ RUBY
 }
 
 customize_repository_type() {
+  # Additional repository types can be added here with a supporting functions
+  # file `customize-repository-<type>.functions.sh`, providing the following
+  # functions:
+  #
+  # - customize_repository_<type>_index "$repo_url"
+  #    - prints repo index YAML to stdout
+  # - customize_repository_<type>_install "$repo_name" "$repo_url" "$profile_name" "$target"
+  #    - copies a profile from a repo to a target directory
+  # - customize_repository_<type>_push "$repo_url" "$src_directory"
+  #    - copies a profile from a directory to a repo
+  # - customize_repository_<type>_set_index "$repo_url" "$index_file"
+  #    - copies an index YAML file to a repo
   local url
   url="$1"
   if [[ "$url" == "http:/"* || "$url" == "https:/"* ]]; then

--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -67,3 +67,23 @@ end
   end
 RUBY
 }
+
+_list_repo_names() {
+  ruby_run <<RUBY
+require 'yaml'
+repo_list = YAML.load_file("${_DEFAULT_CONF_FILE}")["repositories"]
+
+repo_list.keys.each do |name|
+  puts name
+end
+RUBY
+}
+
+customize_repository_each() {
+  local callback r repos
+  callback="$1"
+  repos=$(_list_repo_names)
+  for r in $repos; do
+    $callback "$r"
+  done
+}

--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -67,10 +67,18 @@ def installed?(profile_name)
   File.exists?("${cw_CLUSTER_CUSTOMIZER_path}/${repo_name}-#{profile_name}")
 end
 
+def hidden?(profile)
+  !profile.key? "tags" || !profile["tags"].include("hidden")
+end
+
+def should_list?(profile_name, profile)
+  !installed?(profile_name) && !hidden?(profile)
+end
+
   manifest = YAML.load_file("${manifest_file}") || {}
 
   if manifest.is_a? Hash && manifest.key? "profiles"
-    manifest["profiles"].reject {|p| installed?(p) }.each do | profile_name, profile |
+    manifest["profiles"].select {|prn, pr| should_list?(prn, pr) }.each do | profile_name, profile |
       puts "${repo_name}/#{bold(profile_name)}"
     end
   end

--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -40,6 +40,7 @@ customize_repository_index() {
   require "customize-repository-${repo_type}"
 
   customize_repository_${repo_type}_index "$repo_url"
+  return $?
 }
 
 customize_repository_list_profiles() {
@@ -57,10 +58,12 @@ def bold(text)
   colorize(text, 1)
 end
 
-  manifest = YAML.load_file("${manifest_file}")
+  manifest = YAML.load_file("${manifest_file}") || {}
 
-  manifest["profiles"].each do | profile_name, profile |
-    puts "${repo_name}/#{bold(profile_name)}"
+  if manifest.key? "profiles"
+    manifest["profiles"].each do | profile_name, profile |
+      puts "${repo_name}/#{bold(profile_name)}"
+    end
   end
 RUBY
 }

--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -233,9 +233,10 @@ customize_repository_apply() {
 
 
 customize_repository_push() {
-  local index profile_name repo_type repo_url retval src tmpdir
+  local hook_name index profile_name repo_type repo_url retval src tmpdir
   src="$1"
   repo_name="${2:-account}"  # By default use account bucket
+  hook_name="${3:-configure}" # configure.d is the default hook
   repo_url=$(customize_repository_get_url "$repo_name")
   if [[ ! "$repo_url" ]]; then
     echo "Unknown repository: ${repo_name}"
@@ -251,8 +252,8 @@ customize_repository_push() {
   if [[ -f "$src" ]]; then
     tmpdir="/tmp/${profile_name}"
 
-    mkdir -p "${tmpdir}/configure.d"
-    cp "$src" "${tmpdir}/configure.d"
+    mkdir -p "${tmpdir}/${hook_name}.d"
+    cp "$src" "${tmpdir}/${hook_name}.d"
     src="$tmpdir"
   fi
 

--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -99,10 +99,16 @@ customize_repository_apply() {
   require "customize-repository-${repo_type}"
 
   target="${cw_CLUSTER_CUSTOMIZER_path}/${repo_name}-${profile_name}"
+  mkdir "$target"
 
   customize_repository_${repo_type}_install "$repo_name" "$repo_url" "$profile_name" "$target"
 
   if [[ $? -eq 0 ]]; then
+    if rmdir "${target}" 2>/dev/null; then
+      # If rmdir succeeds then the directory was empty => install failed
+      echo "No profile found for: ${repo_name}/${profile_name}"
+      return 1
+    fi
     chmod -R a+x "${cw_CLUSTER_CUSTOMIZER_path}/${repo_name}-${profile_name}"
     echo "Running configure for $profile_name"
     customize_run_hooks "configure:$repo_name-$profile_name"

--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -1,4 +1,25 @@
 #!/bin/bash
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
 
 require ruby
 require member

--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -28,3 +28,26 @@ customize_repository_type() {
     echo "file"
   fi
 }
+
+customize_repository_list() {
+  local manifest_file repo_name
+  repo_name="$1"
+  manifest_file="$2"
+  ruby_run <<RUBY
+require 'yaml'
+
+def colorize(text, color_code)
+  "\e[#{color_code}m#{text}\e[0m"
+end
+
+def bold(text)
+  colorize(text, 1)
+end
+
+  manifest = YAML.load_file("${manifest_file}")
+
+  manifest["profiles"].each do | profile_name, profile |
+    puts "${repo_name}/#{bold(profile_name)}"
+  end
+RUBY
+}

--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -2,10 +2,12 @@
 
 require ruby
 
+_DEFAULT_CONF_FILE="${cw_ROOT}/etc/cluster-customizer/config.yml"
+
 customize_repository_get_url() {
   local conffile name
   name="$1"
-  conffile="${2:-${cw_ROOT}/etc/cluster-customizer/config.yml}"
+  conffile="${2:-$_DEFAULT_CONF_FILE}"
 
   ruby_run <<RUBY
 require 'yaml'
@@ -27,6 +29,17 @@ customize_repository_type() {
   elif [[ "$url" == "/"* ]]; then
     echo "file"
   fi
+}
+
+customize_repository_index() {
+  local repo_name repo_url repo_type
+  repo_name="$1"
+  repo_url=$(customize_repository_get_url "$repo_name")
+  repo_type=$(customize_repository_type "$repo_url")
+
+  require "customize-repository-${repo_type}"
+
+  customize_repository_${repo_type}_index "$repo_url"
 }
 
 customize_repository_list_profiles() {

--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -218,3 +218,41 @@ customize_repository_apply() {
   fi
 
 }
+
+
+customize_repository_push() {
+  local dest repo_type repo_url src
+  src="$1"
+  dest="${2:-account}"  # By default use account bucket
+  echo "Push $src to $dest"
+
+  repo_url=$(customize_repository_get_url "$repo_name")
+  if [[ ! "$repo_url" ]]; then
+    echo "Unknown repository: ${repo_name}"
+    return 1
+  fi
+  repo_type=$(customize_repository_type "$repo_url")
+
+  require "customize-repository-${repo_type}"
+
+  if [[ -d "$src" ]]; then
+    echo "Source is a directory; assuming it's correctly set up as a profile"
+
+    # Generate (or re-generate) manifest.txt
+    pushd "$src"
+    find -H */* -type f -print > manifest.txt
+    popd
+
+    # TODO update/create index.yml
+
+    customize_repository_${repo_type}_push "$repo_url" "$src"
+
+  elif [[ -f "$src" ]]; then
+    echo "Source is a file - this is not yet supported"
+    return 2
+  else
+    echo "Unknown type: $src"
+    return 3
+  fi
+
+}

--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -174,7 +174,7 @@ _is_installable() {
   profile_name="$2"
   tags=$(customize_repository_tags_for "$repo_name" "$profile_name")
 
-  if [[ "$tags" == *"pre-init"* ]]; then
+  if [[ "$tags" == *"startup"* ]]; then
     return 1
   fi
   return 0

--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -29,7 +29,7 @@ customize_repository_type() {
   fi
 }
 
-customize_repository_list() {
+customize_repository_list_profiles() {
   local manifest_file repo_name
   repo_name="$1"
   manifest_file="$2"

--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+require ruby
+
+customize_repository_get_url() {
+  local conffile name
+  name="$1"
+  conffile="${2:-${cw_ROOT}/etc/cluster-customizer/config.yml}"
+
+  ruby_run <<\RUBY
+require 'yaml'
+repo_list = YAML.load_file("${conffile}")["repositories"]
+
+if repo_list.key? "${name}"
+  puts repo_list["${name}"]
+end
+RUBY
+}
+
+customize_repository_type() {
+  local url
+  url="$1"
+  if [[ "$url" == "http:/"* || "$url" == "https:/"* ]]; then
+    echo "http"
+  elif [[ "$url" == "s3:/"* ]]; then
+    echo "s3"
+  elif [[ "$url" == "/"* ]]; then
+    echo "file"
+  fi
+}

--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -68,7 +68,7 @@ def installed?(profile_name)
 end
 
 def hidden?(profile)
-  !profile.key? "tags" || !profile["tags"].include("hidden")
+  profile.key?("tags") && profile["tags"].include?("hidden")
 end
 
 def should_list?(profile_name, profile)

--- a/clusterware-customize/lib/functions/customize.functions.sh
+++ b/clusterware-customize/lib/functions/customize.functions.sh
@@ -242,104 +242,6 @@ customize_fetch() {
     customize_clear_s3_config
 }
 
-customize_list_from_s3() {
-    local all avail prohibited profile_type s3cfg url f
-    s3cfg=$1
-    url=$2
-    profile_type=$3
-    all=$("${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} --recursive ls "${url}")
-
-    if [ "$profile_type" == "features" -a -n "${_SET_PREFIX}" ]; then
-        f=6
-    else
-        f=5
-    fi
-
-    prohibited=$(echo "$all" | grep -E "(initialize|preconfigure)\.d" | cut -f$f -d'/' | uniq | grep -v '^$')
-    avail=$(echo "$all" | cut -f$f -d'/' | uniq | grep -v '^$')
-
-    customize_print_list_excluding "$avail" "$prohibited" ""
-}
-
-customize_list_from_http() {
-  local all host prohibited source prefix index
-  source="$1"
-  prefix="$2"
-  if [ "${_REGION:-${cw_CLUSTER_CUSTOMIZER_region:-eu-west-1}}" == "us-east-1" ]; then
-      host=s3.amazonaws.com
-  else
-      host=s3-${_REGION:-${cw_CLUSTER_CUSTOMIZER_region:-eu-west-1}}.amazonaws.com
-  fi
-  index=$(curl -s -f https://${host}/${source}/)
-  if [[ $? -eq 0 ]]; then
-    all=$(echo "$index" | grep -oP '(?<=\<Key>'$prefix'\/)[^\<]+?(?=\/manifest.txt\<\/Key\>)')
-    prohibited=$(echo "$index" | grep -oP '(?<=\<Key>'$prefix'\/)[^\<]+?(?=\/(initialize|preconfigure)\.d.*\<\/Key\>)')
-    customize_print_list_excluding "$all" "$prohibited" ""
-  else
-    echo "HTTPS call failed, customization listing unavailable."
-    return 1
-  fi
-}
-
-customize_print_list_excluding() {
-  local ex existing av avail found prefix
-  avail="$1"
-  existing="$2"
-  prefix="$3"
-  for av in $avail; do
-    found=false
-    for ex in $existing; do
-      if [[ "$av" == "$ex" ]]; then
-        found=true
-        break
-      fi
-    done
-    if [[ "$found" == false ]]; then
-      echo "$prefix$av"
-    fi
-  done
-}
-
-customize_list_profiles() {
-  local bucket existing avail
-  if [ -z "${cw_CLUSTER_CUSTOMIZER_bucket}" ]; then
-      if network_is_ec2; then
-          bucket="alces-flight-$(network_ec2_hashed_account)"
-      else
-          echo "Unable to determine bucket name for customizations"
-          return 0
-      fi
-  else
-      bucket="${cw_CLUSTER_CUSTOMIZER_bucket#s3://}"
-  fi
-  existing=$(ls "${cw_CLUSTER_CUSTOMIZER_path}" | grep -Po "(?<=profile-).*")
-  if ! customize_is_s3_access_available "${s3cfg}" "${bucket}"; then
-      echo "S3 access to '${bucket}' is not available.  Falling back to HTTP manifests."
-      s3cfg=""
-      avail=$(customize_list_from_http "$bucket" "customizer")
-  else
-    avail=$(customize_list_from_s3 "$s3cfg" "s3://${bucket}/customizer" account)
-  fi
-  customize_print_list_excluding "$avail" "$existing" " - profile/"
-}
-
-customize_list_features() {
-  local bucket s3cfg existing avail
-  s3cfg="$1"
-  bucket="alces-flight-profiles-${_REGION}"
-
-  existing=$(ls "${cw_CLUSTER_CUSTOMIZER_path}" | grep -Po "(?<=feature-).*")
-
-  if ! customize_is_s3_access_available "${s3cfg}" "${bucket}"; then
-      echo "S3 access to '${bucket}' is not available.  Falling back to HTTP manifests."
-      s3cfg=""
-      avail=$(customize_list_from_http "$bucket" "${_SET_PREFIX}features")
-  else
-    avail=$(customize_list_from_s3 "$s3cfg" "s3://${bucket}/${_SET_PREFIX}features" features)
-  fi
-  customize_print_list_excluding "$avail" "$existing" " - feature/"
-}
-
 customize_list() {
   local repo_name tmpfile
 
@@ -377,32 +279,6 @@ _run_member_hooks() {
     fi
 }
 
-customize_profile_can_be_installed() {
-  local expression initCount s3cfg source
-  s3cfg="$1"
-  source="$2"
-
-  expression="(initialize|preconfigure)\.d"
-
-  if [ "$s3cfg" ]; then
-    initCount=$("${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} ls "s3://${source}"/ | grep -E "$expression" | wc -l)
-  else
-    if [ "${_REGION:-${cw_CLUSTER_CUSTOMIZER_region:-eu-west-1}}" == "us-east-1" ]; then
-        host=s3.amazonaws.com
-    else
-        host=s3-${_REGION:-${cw_CLUSTER_CUSTOMIZER_region:-eu-west-1}}.amazonaws.com
-    fi
-    initCount=$(curl -s -f https://${host}/${source}/manifest.txt | grep -E "$expression" | wc -l)
-  fi
-
-  if [[ $initCount == 0 ]]; then
-    return 0
-  else
-    echo "Cannot apply profile. This profile requires installation before cluster initialization and does not support being applied while the cluster is running."
-    return 1
-  fi
-}
-
 customize_apply() {
   local repo_name profile_name
   repo_name="$1"
@@ -410,45 +286,4 @@ customize_apply() {
 
   require customize-repository
   customize_repository_apply "$repo_name" "$profile_name"
-}
-
-customize_apply_profile() {
-  local bucket profile_name
-  profile_name="$1"
-
-  customize_set_s3_config
-  customize_set_feature_set
-
-  if [ -z "${cw_CLUSTER_CUSTOMIZER_bucket}" ]; then
-      if network_is_ec2; then
-          bucket="alces-flight-$(network_ec2_hashed_account)"
-      else
-          echo "Unable to determine bucket name for customizations"
-          return 0
-      fi
-  else
-      bucket="${cw_CLUSTER_CUSTOMIZER_bucket#s3://}"
-  fi
-
-  echo "Applying profile $profile_name..."
-
-  customize_apply "$bucket" "$profile_name" "profile" "job-queue.d/*"
-
-  customize_clear_s3_config
-}
-
-customize_apply_feature() {
-  local bucket feature_name
-  feature_name="$1"
-
-  customize_set_s3_config
-  customize_set_feature_set
-
-  bucket="alces-flight-profiles-${_REGION}"
-
-  echo "Applying feature $feature_name..."
-
-  customize_apply "$bucket" "$feature_name" "feature"
-
-  customize_clear_s3_config
 }

--- a/clusterware-customize/lib/functions/customize.functions.sh
+++ b/clusterware-customize/lib/functions/customize.functions.sh
@@ -1,0 +1,471 @@
+#==============================================================================
+# Copyright (C) 2016 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+require files
+
+customize_list_hooks() {
+    local p paths with_events e
+    if [ "$1" == "--with-events" ]; then
+        with_events=true
+        shift
+    fi
+    files_load_config cluster-customizer
+    cw_CLUSTER_CUSTOMIZER_path=${cw_CLUSTER_CUSTOMIZER_path:-"${cw_ROOT}"/var/lib/customizer}
+    paths="${cw_CLUSTER_CUSTOMIZER_custom_paths}"
+    for p in ${cw_CLUSTER_CUSTOMIZER_path}/*; do
+        paths="${paths} ${p}"
+    done
+    for p in ${paths}; do
+        if [ "${with_events}" ]; then
+            for e in "${p}"/*; do
+                echo -e "\e[38;5;221m$(basename "${p}")\e[0m/\e[35m$(basename "${e}" .d)\e[0m"
+            done
+        else
+            basename "${p}"
+        fi
+    done
+}
+
+customize_run_hooks() {
+    local a p hook paths feature
+    hook="$1"
+    if [[ "$hook" == *":"* ]]; then
+        feature="${hook#*:}"
+        hook="${hook%:*}"
+    fi
+    shift
+    files_load_config config config/cluster
+    files_load_config instance config/cluster
+    files_load_config cluster-customizer
+    cw_CLUSTER_CUSTOMIZER_path=${cw_CLUSTER_CUSTOMIZER_path:-"${cw_ROOT}"/var/lib/customizer}
+    paths="${cw_CLUSTER_CUSTOMIZER_custom_paths}"
+    for p in ${cw_CLUSTER_CUSTOMIZER_path}/*; do
+        paths="${paths} ${p}"
+    done
+    for p in ${paths}; do
+        if [[ -z "${feature}" || "${p}" == */"${feature}" ]]; then
+            if [ -d "${p}"/${hook}.d ]; then
+                for a in "${p}"/${hook}.d/*; do
+                    if [ -x "$a" -a ! -d "$a" ] && [[ "$a" != *~ ]]; then
+                        echo "Running $hook hook: ${a}"
+                        "${a}" "${hook}" \
+                               "${cw_INSTANCE_role}" \
+                               "${cw_CLUSTER_name}" \
+                               "$@"
+                    elif [[ "$a" != *~ ]]; then
+                        echo "Skipping non-executable $hook hook: ${a}"
+                    fi
+                done
+            else
+                echo "No $hook hooks found in ${p}"
+            fi
+        fi
+    done
+}
+
+customize_set_region() {
+    if [ -z "${_REGION}" ]; then
+        if network_is_ec2; then
+            eval $(network_fetch_ec2_document | "${cw_ROOT}"/opt/jq/bin/jq -r '"_REGION=\(.region)"')
+        else
+            _REGION="${cw_CLUSTER_CUSTOMIZER_region:-eu-west-1}"
+        fi
+    fi
+}
+
+customize_set_machine_type() {
+    if [ -z "${_MACHINE_TYPE}" ]; then
+        _MACHINE_TYPE="$(network_fetch_ec2_metadata instance-type)"
+    fi
+}
+
+customize_fetch_profile() {
+    local s3cfg source target host manifest f s3cmd excludes
+    s3cfg="$1"
+    source="$2"
+    target="$3"
+    excludes="$4"
+    mkdir -p "${target}"
+    if [ "${s3cfg}" ]; then
+        # Create bucket if it does not already exist
+        "${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} mb "s3://${source%%/*}" &>/dev/null
+        local args
+        args=(--force -r)
+        if [ -n "${excludes}" ] ; then
+            args+=(--exclude)
+            args+=(${excludes})
+        fi
+        "${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} ${args[@]} get "s3://${source}"/ "${target}"
+        if rmdir "${target}" 2>/dev/null; then
+            echo "No profile found for: ${source}"
+            return 1
+        fi
+    else
+        # fetch manifest file
+        if [ "${_REGION:-${cw_CLUSTER_CUSTOMIZER_region:-eu-west-1}}" == "us-east-1" ]; then
+            host=s3.amazonaws.com
+        else
+            host=s3-${_REGION:-${cw_CLUSTER_CUSTOMIZER_region:-eu-west-1}}.amazonaws.com
+        fi
+        manifest=$(curl -s -f https://${host}/${source}/manifest.txt)
+        if [ "${manifest}" ] && ! echo "${manifest[*]}" | grep -q '<Error>'; then
+            # fetch each file within manifest file
+            for f in ${manifest}; do
+                mkdir -p "${target}/$(dirname "$f")"
+                if curl -s -f -o ${target}/${f} https://${host}/${source}/${f}; then
+                    echo "Fetched: ${source}/${f}"
+                else
+                    echo "Unable to fetch: ${source}/${f}"
+                    return 1
+                fi
+            done
+        else
+            echo "No manifest found for: ${source}"
+            return 1
+        fi
+    fi
+}
+
+customize_fetch_machine_type() {
+    local bucket prefix
+    s3cfg=$1
+    bucket="alces-flight-profiles-${_REGION}"
+    if ! customize_is_s3_access_available "${s3cfg}" "${bucket}"; then
+        echo "S3 access to '${bucket}' is not available.  Falling back to HTTP manifests."
+        s3cfg=""
+    fi
+    prefix="${_SET_PREFIX}machines/${_MACHINE_TYPE}"
+    echo "Retrieving machine type customizations from: ${bucket}/${prefix}"
+    customize_fetch_profile "${s3cfg}" "${bucket}/${prefix}" \
+                            "${cw_CLUSTER_CUSTOMIZER_path}"/machine-${_MACHINE_TYPE}
+}
+
+customize_fetch_features() {
+    local bucket feature s3cfg
+    s3cfg=$1
+    bucket="alces-flight-profiles-${_REGION}"
+    if ! customize_is_s3_access_available "${s3cfg}" "${bucket}"; then
+        echo "S3 access to '${bucket}' is not available.  Falling back to HTTP manifests."
+        s3cfg=""
+    fi
+    for feature in ${cw_CLUSTER_CUSTOMIZER_features}; do
+        echo "Retrieving feature customizations from: ${bucket}/${_SET_PREFIX}features/$feature"
+        customize_fetch_profile "${s3cfg}" "${bucket}"/${_SET_PREFIX}features/"${feature}" \
+                                "${cw_CLUSTER_CUSTOMIZER_path}"/feature-${feature}
+    done
+}
+
+customize_fetch_profiles() {
+    local bucket profile
+    if [ -z "${cw_CLUSTER_CUSTOMIZER_bucket}" ]; then
+        if network_is_ec2; then
+            bucket="alces-flight-$(network_ec2_hashed_account)"
+        else
+            echo "Unable to determine bucket name for customizations"
+            return 0
+        fi
+    else
+        bucket="${cw_CLUSTER_CUSTOMIZER_bucket#s3://}"
+    fi
+    if ! customize_is_s3_access_available "${s3cfg}" "${bucket}"; then
+        echo "S3 access to '${bucket}' is not available.  Falling back to HTTP manifests."
+        s3cfg=""
+    fi
+    for profile in ${cw_CLUSTER_CUSTOMIZER_profiles}; do
+        echo "Retrieving customizations from: ${bucket}/customizer/$profile"
+        customize_fetch_profile "${s3cfg}" "${bucket}"/customizer/"${profile}" \
+                                "${cw_CLUSTER_CUSTOMIZER_path}"/profile-${profile} \
+                                "*job-queue.d/*"
+    done
+}
+
+customize_is_s3_access_available() {
+    local s3cfg bucket
+    s3cfg="$1"
+    bucket="$2"
+    "${cw_ROOT}"/opt/s3cmd/s3cmd -q -c ${s3cfg} ls "s3://${bucket}" 2>/dev/null
+}
+
+customize_set_feature_set() {
+    if [ "${cw_CLUSTER_CUSTOMIZER_feature_set}" ]; then
+        _SET_PREFIX="${cw_CLUSTER_CUSTOMIZER_feature_set}/"
+    fi
+}
+
+customize_set_s3_config() {
+  customize_set_region
+  s3cfg="$(mktemp /tmp/cluster-customizer.s3cfg.XXXXXXXX)"
+  cat <<EOF > "${s3cfg}"
+[default]
+access_key = "${cw_CLUSTER_CUSTOMIZER_access_key_id}"
+secret_key = "${cw_CLUSTER_CUSTOMIZER_secret_access_key}"
+security_token = ""
+use_https = True
+check_ssl_certificate = True
+EOF
+}
+
+customize_clear_s3_config() {
+  rm -f "${s3cfg}"
+  unset s3cfg
+}
+
+customize_fetch() {
+    customize_set_s3_config
+    customize_set_feature_set
+    mkdir -p "${cw_CLUSTER_CUSTOMIZER_path}"
+    customize_set_machine_type
+    if [ "${_MACHINE_TYPE}" ]; then
+        customize_fetch_machine_type "${s3cfg}"
+    fi
+    customize_fetch_features "${s3cfg}"
+    customize_fetch_profiles "${s3cfg}"
+    chmod -R a+x "${cw_CLUSTER_CUSTOMIZER_path}"
+    customize_clear_s3_config
+}
+
+customize_list_from_s3() {
+    local all avail prohibited profile_type s3cfg url f
+    s3cfg=$1
+    url=$2
+    profile_type=$3
+    all=$("${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} --recursive ls "${url}")
+
+    if [ "$profile_type" == "features" -a -n "${_SET_PREFIX}" ]; then
+        f=6
+    else
+        f=5
+    fi
+
+    prohibited=$(echo "$all" | grep -E "(initialize|preconfigure)\.d" | cut -f$f -d'/' | uniq | grep -v '^$')
+    avail=$(echo "$all" | cut -f$f -d'/' | uniq | grep -v '^$')
+
+    customize_print_list_excluding "$avail" "$prohibited" ""
+}
+
+customize_list_from_http() {
+  local all host prohibited source prefix index
+  source="$1"
+  prefix="$2"
+  if [ "${_REGION:-${cw_CLUSTER_CUSTOMIZER_region:-eu-west-1}}" == "us-east-1" ]; then
+      host=s3.amazonaws.com
+  else
+      host=s3-${_REGION:-${cw_CLUSTER_CUSTOMIZER_region:-eu-west-1}}.amazonaws.com
+  fi
+  index=$(curl -s -f https://${host}/${source}/)
+  if [[ $? -eq 0 ]]; then
+    all=$(echo "$index" | grep -oP '(?<=\<Key>'$prefix'\/)[^\<]+?(?=\/manifest.txt\<\/Key\>)')
+    prohibited=$(echo "$index" | grep -oP '(?<=\<Key>'$prefix'\/)[^\<]+?(?=\/(initialize|preconfigure)\.d.*\<\/Key\>)')
+    customize_print_list_excluding "$all" "$prohibited" ""
+  else
+    echo "HTTPS call failed, customization listing unavailable."
+    return 1
+  fi
+}
+
+customize_print_list_excluding() {
+  local ex existing av avail found prefix
+  avail="$1"
+  existing="$2"
+  prefix="$3"
+  for av in $avail; do
+    found=false
+    for ex in $existing; do
+      if [[ "$av" == "$ex" ]]; then
+        found=true
+        break
+      fi
+    done
+    if [[ "$found" == false ]]; then
+      echo "$prefix$av"
+    fi
+  done
+}
+
+customize_list_profiles() {
+  local bucket existing avail
+  if [ -z "${cw_CLUSTER_CUSTOMIZER_bucket}" ]; then
+      if network_is_ec2; then
+          bucket="alces-flight-$(network_ec2_hashed_account)"
+      else
+          echo "Unable to determine bucket name for customizations"
+          return 0
+      fi
+  else
+      bucket="${cw_CLUSTER_CUSTOMIZER_bucket#s3://}"
+  fi
+  existing=$(ls "${cw_CLUSTER_CUSTOMIZER_path}" | grep -Po "(?<=profile-).*")
+  if ! customize_is_s3_access_available "${s3cfg}" "${bucket}"; then
+      echo "S3 access to '${bucket}' is not available.  Falling back to HTTP manifests."
+      s3cfg=""
+      avail=$(customize_list_from_http "$bucket" "customizer")
+  else
+    avail=$(customize_list_from_s3 "$s3cfg" "s3://${bucket}/customizer" account)
+  fi
+  customize_print_list_excluding "$avail" "$existing" " - profile/"
+}
+
+customize_list_features() {
+  local bucket s3cfg existing avail
+  s3cfg="$1"
+  bucket="alces-flight-profiles-${_REGION}"
+
+  existing=$(ls "${cw_CLUSTER_CUSTOMIZER_path}" | grep -Po "(?<=feature-).*")
+
+  if ! customize_is_s3_access_available "${s3cfg}" "${bucket}"; then
+      echo "S3 access to '${bucket}' is not available.  Falling back to HTTP manifests."
+      s3cfg=""
+      avail=$(customize_list_from_http "$bucket" "${_SET_PREFIX}features")
+  else
+    avail=$(customize_list_from_s3 "$s3cfg" "s3://${bucket}/${_SET_PREFIX}features" features)
+  fi
+  customize_print_list_excluding "$avail" "$existing" " - feature/"
+}
+
+customize_list() {
+  customize_set_s3_config
+  customize_set_feature_set
+  customize_list_profiles "${s3cfg}"
+  customize_list_features "${s3cfg}"
+  customize_clear_s3_config
+}
+
+_run_member_hooks() {
+    local event name ip
+    members="$1"
+    event="$2"
+    shift 3
+    name="$1"
+    ip="$2"
+    if [[ -z "${members}" || ,"$members", == *,"${name}",* ]]; then
+       customize_run_hooks "${event}" \
+                           "${cw_MEMBER_DIR}"/"${name}" \
+                           "${name}" \
+                           "${ip}"
+    fi
+}
+
+customize_profile_can_be_installed() {
+  local expression initCount s3cfg source
+  s3cfg="$1"
+  source="$2"
+
+  expression="(initialize|preconfigure)\.d"
+
+  if [ "$s3cfg" ]; then
+    initCount=$("${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} ls "s3://${source}"/ | grep -E "$expression" | wc -l)
+  else
+    if [ "${_REGION:-${cw_CLUSTER_CUSTOMIZER_region:-eu-west-1}}" == "us-east-1" ]; then
+        host=s3.amazonaws.com
+    else
+        host=s3-${_REGION:-${cw_CLUSTER_CUSTOMIZER_region:-eu-west-1}}.amazonaws.com
+    fi
+    initCount=$(curl -s -f https://${host}/${source}/manifest.txt | grep -E "$expression" | wc -l)
+  fi
+
+  if [[ $initCount == 0 ]]; then
+    return 0
+  else
+    echo "Cannot apply profile. This profile requires installation before cluster initialization and does not support being applied while the cluster is running."
+    return 1
+  fi
+}
+
+customize_apply() {
+  local bucket name type varname sourcepath excludes
+  bucket="$1"
+  name="$2"
+  type="$3"
+  excludes="$4"
+
+  if ! customize_is_s3_access_available "${s3cfg}" "${bucket}"; then
+      echo "S3 access to '${bucket}' is not available.  Falling back to HTTP manifests."
+      s3cfg=""
+  fi
+
+  if [[ "$type" == "feature" ]] ; then
+    varname="cw_CLUSTER_CUSTOMIZER_features"
+    sourcepath="${_SET_PREFIX}features"
+  else
+    varname="cw_CLUSTER_CUSTOMIZER_profiles"
+    sourcepath="customizer"
+  fi
+
+  if customize_profile_can_be_installed "$s3cfg" "${bucket}/${sourcepath}/$name"; then
+
+    echo "Retrieving customization from: ${bucket}/${sourcepath}/$name"
+    customize_fetch_profile "${s3cfg}" "${bucket}/${sourcepath}/$name" \
+                            "${cw_CLUSTER_CUSTOMIZER_path}/${type}-${name}" \
+                            "${excludes}"
+
+    if [[ $? -eq 0 ]]; then
+      sed -i "s/$varname=.*/$varname=\"${!varname} $name\"/" "$cw_ROOT"/etc/cluster-customizer.rc
+      chmod -R a+x "${cw_CLUSTER_CUSTOMIZER_path}/${type}-${name}"
+      echo "Running configure for $name"
+      customize_run_hooks "configure:$type-$name"
+      member_each _run_member_hooks "${members}" "member-join:$type-$name"
+      return 0
+    fi
+  fi
+  echo "Applying profile failed."
+  return 1
+}
+
+customize_apply_profile() {
+  local bucket profile_name
+  profile_name="$1"
+
+  customize_set_s3_config
+  customize_set_feature_set
+
+  if [ -z "${cw_CLUSTER_CUSTOMIZER_bucket}" ]; then
+      if network_is_ec2; then
+          bucket="alces-flight-$(network_ec2_hashed_account)"
+      else
+          echo "Unable to determine bucket name for customizations"
+          return 0
+      fi
+  else
+      bucket="${cw_CLUSTER_CUSTOMIZER_bucket#s3://}"
+  fi
+
+  echo "Applying profile $profile_name..."
+
+  customize_apply "$bucket" "$profile_name" "profile" "job-queue.d/*"
+
+  customize_clear_s3_config
+}
+
+customize_apply_feature() {
+  local bucket feature_name
+  feature_name="$1"
+
+  customize_set_s3_config
+  customize_set_feature_set
+
+  bucket="alces-flight-profiles-${_REGION}"
+
+  echo "Applying feature $feature_name..."
+
+  customize_apply "$bucket" "$feature_name" "feature"
+
+  customize_clear_s3_config
+}

--- a/clusterware-customize/lib/functions/customize.functions.sh
+++ b/clusterware-customize/lib/functions/customize.functions.sh
@@ -260,9 +260,8 @@ customize_avail() {
     else
       echo "Could not retrieve repository index for ${repo_name}."
     fi
-    rm "$tmpfile"
   fi
-
+  rm "$tmpfile"
 }
 
 customize_apply() {

--- a/clusterware-customize/lib/functions/customize.functions.sh
+++ b/clusterware-customize/lib/functions/customize.functions.sh
@@ -22,7 +22,7 @@
 require files
 
 customize_list_hooks() {
-    local p paths with_events e
+    local b p paths with_events e
     if [ "$1" == "--with-events" ]; then
         with_events=true
         shift
@@ -39,7 +39,8 @@ customize_list_hooks() {
                 echo -e "\e[38;5;221m$(basename "${p}")\e[0m/\e[35m$(basename "${e}" .d)\e[0m"
             done
         else
-            basename "${p}"
+            b=$(basename "${p}")
+            echo -e "${b%%-*}/\e[1m${b#*-}\e[0m"
         fi
     done
 }

--- a/clusterware-customize/lib/functions/customize.functions.sh
+++ b/clusterware-customize/lib/functions/customize.functions.sh
@@ -243,7 +243,7 @@ customize_fetch() {
     customize_clear_s3_config
 }
 
-customize_list() {
+customize_avail() {
   local repo_name tmpfile
 
   require customize-repository
@@ -252,7 +252,7 @@ customize_list() {
   tmpfile=$(mktemp "/tmp/cluster-customizer.s3cfg.XXXXXXXX")
 
   if [[ "$repo_name" == "" ]]; then
-    customize_repository_each customize_list
+    customize_repository_each customize_avail
   else
     customize_repository_index "$repo_name" > "$tmpfile"
     if [ "$?" == 0 ]; then

--- a/clusterware-customize/lib/functions/customize.functions.sh
+++ b/clusterware-customize/lib/functions/customize.functions.sh
@@ -174,7 +174,7 @@ customize_fetch_features() {
     done
 }
 
-customize_fetch_profiles() {
+customize_fetch_account_profiles() {
     local bucket profile
     if [ -z "${cw_CLUSTER_CUSTOMIZER_bucket}" ]; then
         if network_is_ec2; then
@@ -190,7 +190,7 @@ customize_fetch_profiles() {
         echo "S3 access to '${bucket}' is not available.  Falling back to HTTP manifests."
         s3cfg=""
     fi
-    for profile in ${cw_CLUSTER_CUSTOMIZER_profiles}; do
+    for profile in ${cw_CLUSTER_CUSTOMIZER_account_profiles}; do
         echo "Retrieving customizations from: ${bucket}/customizer/$profile"
         customize_fetch_profile "${s3cfg}" "${bucket}"/customizer/"${profile}" \
                                 "${cw_CLUSTER_CUSTOMIZER_path}"/profile-${profile} \
@@ -238,7 +238,7 @@ customize_fetch() {
         customize_fetch_machine_type "${s3cfg}"
     fi
     customize_fetch_features "${s3cfg}"
-    customize_fetch_profiles "${s3cfg}"
+    customize_fetch_account_profiles "${s3cfg}"
     chmod -R a+x "${cw_CLUSTER_CUSTOMIZER_path}"
     customize_clear_s3_config
 }

--- a/clusterware-customize/lib/functions/customize.functions.sh
+++ b/clusterware-customize/lib/functions/customize.functions.sh
@@ -341,11 +341,25 @@ customize_list_features() {
 }
 
 customize_list() {
-  customize_set_s3_config
-  customize_set_feature_set
-  customize_list_profiles "${s3cfg}"
-  customize_list_features "${s3cfg}"
-  customize_clear_s3_config
+  local repo_name tmpfile
+
+  require customize-repository
+
+  repo_name="$1"
+  tmpfile=$(mktemp "/tmp/cluster-customizer.s3cfg.XXXXXXXX")
+
+  if [[ "$repo_name" == "" ]]; then
+    echo "No repo name specified"
+  else
+    customize_repository_index "$repo_name" > "$tmpfile"
+    if [ "$?" == 0 ]; then
+      customize_repository_list_profiles "$repo_name" "$tmpfile"
+    else
+      echo "Could not retrieve repository index."
+    fi
+    rm "$tmpfile"
+  fi
+
 }
 
 _run_member_hooks() {

--- a/clusterware-customize/lib/functions/customize.functions.sh
+++ b/clusterware-customize/lib/functions/customize.functions.sh
@@ -146,7 +146,7 @@ customize_fetch_profile() {
 }
 
 customize_fetch_machine_type() {
-    local bucket prefix
+    local bucket prefix s3cfg
     s3cfg=$1
     bucket="alces-flight-profiles-${_REGION}"
     if ! customize_is_s3_access_available "${s3cfg}" "${bucket}"; then
@@ -175,7 +175,7 @@ customize_fetch_features() {
 }
 
 customize_fetch_account_profiles() {
-    local bucket profile
+    local bucket profile s3cfg
     if [ -z "${cw_CLUSTER_CUSTOMIZER_bucket}" ]; then
         if network_is_ec2; then
             bucket="alces-flight-$(network_ec2_hashed_account)"

--- a/clusterware-customize/lib/functions/customize.functions.sh
+++ b/clusterware-customize/lib/functions/customize.functions.sh
@@ -349,13 +349,13 @@ customize_list() {
   tmpfile=$(mktemp "/tmp/cluster-customizer.s3cfg.XXXXXXXX")
 
   if [[ "$repo_name" == "" ]]; then
-    echo "No repo name specified"
+    customize_repository_each customize_list
   else
     customize_repository_index "$repo_name" > "$tmpfile"
     if [ "$?" == 0 ]; then
       customize_repository_list_profiles "$repo_name" "$tmpfile"
     else
-      echo "Could not retrieve repository index."
+      echo "Could not retrieve repository index for ${repo_name}."
     fi
     rm "$tmpfile"
   fi

--- a/clusterware-customize/lib/functions/customize.functions.sh
+++ b/clusterware-customize/lib/functions/customize.functions.sh
@@ -264,21 +264,6 @@ customize_list() {
 
 }
 
-_run_member_hooks() {
-    local event name ip
-    members="$1"
-    event="$2"
-    shift 3
-    name="$1"
-    ip="$2"
-    if [[ -z "${members}" || ,"$members", == *,"${name}",* ]]; then
-       customize_run_hooks "${event}" \
-                           "${cw_MEMBER_DIR}"/"${name}" \
-                           "${name}" \
-                           "${ip}"
-    fi
-}
-
 customize_apply() {
   local repo_name profile_name
   repo_name="$1"

--- a/clusterware-customize/lib/functions/job-queue.functions.sh
+++ b/clusterware-customize/lib/functions/job-queue.functions.sh
@@ -109,6 +109,7 @@ job_queue_save_job_output() {
     # about python-magic not being available.
 
     "${cw_ROOT}"/opt/s3cmd/s3cmd put --recursive \
+        --acl-public \
         --default-mime-type=text/plain \
         --guess-mime-type \
         --no-mime-magic \

--- a/clusterware-customize/lib/functions/job-queue.functions.sh
+++ b/clusterware-customize/lib/functions/job-queue.functions.sh
@@ -114,6 +114,11 @@ job_queue_save_job_output() {
         --no-mime-magic \
         $(job_queue_work_dir_path "${queue}" "${output_dir}"/"${job_id}"/"$(hostname)") \
         $(job_queue_bucket_path "${queue}" "${output_dir}"/"${job_id}")/
+
+    mkdir -p /var/log/clusterware/prime-continuous-delivery/
+    rsync -a $(job_queue_work_dir_path "${queue}" "${output_dir}"/) \
+        /var/log/clusterware/prime-continuous-delivery/"${output_dir}"/
+
 }
 
 # If there are any objects already stored with job_id, the job is invalid.  We

--- a/clusterware-customize/lib/functions/job-queue.functions.sh
+++ b/clusterware-customize/lib/functions/job-queue.functions.sh
@@ -1,0 +1,347 @@
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+require files
+require network
+
+job_queue_bucket_path() {
+    local queue relative_path
+    queue="$1"
+    relative_path="$2"
+
+    if [ "${relative_path}" == "" ] ; then
+        echo "${BUCKET}"/customizer/"${queue}"/job-queue.d/"${cw_CLUSTER_name}"
+    else
+        echo "${BUCKET}"/customizer/"${queue}"/job-queue.d/"${cw_CLUSTER_name}"/"${relative_path}"
+    fi
+}
+
+job_queue_work_dir_path() {
+    local queue relative_path
+    queue="$1"
+    relative_path="$2"
+
+    if [ "${relative_path}" == "" ] ; then
+        echo "${WORK_DIR}"/"${queue}"
+    else
+        echo "${WORK_DIR}"/"${queue}"/"${relative_path}"
+    fi
+}
+
+# Adds job queue customizers to the `job_queues` array.
+job_queue_get_job_queues() {
+    local customizer all_customizers queue_customizers
+    job_queue_s3cmd_setup
+
+    all_customizers=$( "${cw_ROOT}"/opt/s3cmd/s3cmd ls --recursive "${BUCKET}/customizer/" )
+    queue_customizers=$( echo "${all_customizers}" \
+        | grep "${BUCKET}/customizer/[^/]*/job-queue.d/" \
+        | cut -d/ -f5 \
+        | uniq
+    )
+    for customizer in ${queue_customizers} ; do 
+        job_queues+=("${customizer}")
+    done
+}
+
+job_queue_s3cmd_setup() {
+    files_load_config cluster-customizer
+    files_load_config config config/cluster
+
+    BUCKET="${cw_CLUSTER_CUSTOMIZER_bucket:-s3://alces-flight-$(network_ec2_hashed_account)}"
+    export AWS_ACCESS_KEY_ID="${cw_CLUSTER_CUSTOMIZER_access_key_id}"
+    export AWS_SECRET_ACCESS_KEY="${cw_CLUSTER_CUSTOMIZER_secret_access_key}"
+}
+
+# Download any custom job handling script for the queue.
+job_queue_get_job_handling_customizations() {
+    local queue s3_pending_dir local_pending_dir
+    queue="$1"
+    s3_pending_dir="${BUCKET}"/customizer/"${queue}"/share/
+    local_pending_dir="${WORK_DIR}"/customizer/"${queue}"/share/
+
+    mkdir -p "${local_pending_dir}"
+    "${cw_ROOT}"/opt/s3cmd/s3cmd get --recursive --quiet ${s3_pending_dir} ${local_pending_dir}
+}
+
+job_queue_get_pending_jobs() {
+    local queue s3_pending_dir local_pending_dir
+    queue="$1"
+    s3_pending_dir="$(job_queue_bucket_path "${queue}" pending/)"
+    local_pending_dir="$(job_queue_work_dir_path "${queue}" pending/)"
+
+    mkdir -p "${local_pending_dir}"
+    "${cw_ROOT}"/opt/s3cmd/s3cmd get --recursive --quiet ${s3_pending_dir} ${local_pending_dir}
+}
+
+job_queue_save_job_output() {
+    local queue output_dir job_id
+    queue=$1
+    job_id=$2
+    output_dir=$3
+
+    "${cw_ROOT}"/opt/s3cmd/s3cmd put --quiet --recursive \
+        $(job_queue_work_dir_path "${queue}" "${output_dir}"/"${job_id}"/"$(hostname)") \
+        $(job_queue_bucket_path "${queue}" "${output_dir}"/"${job_id}")/
+}
+
+# If there are any objects already stored with job_id, the job is invalid.  We
+# don't want to overwrite any previous output.
+job_queue_validate_job_id() {
+    local queue job_id rejected_file existing
+    queue=$1
+    job_id=$2
+    rejected_file=$3
+
+    existing=$( "${cw_ROOT}"/opt/s3cmd/s3cmd ls \
+        $(job_queue_bucket_path "${queue}" completed/"${job_id}"/"$(hostname)") \
+        | wc -l
+    )
+
+    if [ $existing -ne 0 ] ; then
+        mkdir -p $(dirname $rejected_file)
+        echo "Job id ${job_id} previously used" > $rejected_file
+        return 1
+    fi
+}
+
+job_queue_validate_job_file() {
+    local queue job_file rejected_dir rejected_file custom_validation_file
+    local exit_code errors
+    queue=$1
+    job_file=$2
+    rejected_dir=$3
+    rejected_file=$4
+    custom_validation_file="${WORK_DIR}"/customizer/"${queue}"/share/validate-job
+
+    if [ -f "${custom_validation_file}" ] ; then
+        chmod +x "${custom_validation_file}"
+        errors=$( "${custom_validation_file}" "${job_file}" "${rejected_dir}" )
+        exit_code=$?
+        if [ $exit_code -ne 0 ] ; then
+            mkdir -p $( dirname "${rejected_file}" )
+            echo "${errors}" > "${rejected_file}"
+        fi
+        return $exit_code
+    else
+        # Job files are valid by default.
+        return 0
+    fi
+}
+
+job_queue_execute_job() {
+    local queue job_file status_file output_dir custom_job_runner exit_code
+    queue=$1
+    job_file=$2
+    status_file=$3
+    output_dir=$4
+    custom_job_runner="${WORK_DIR}"/customizer/"${queue}"/share/process-job
+    files_load_config instance config/cluster
+
+    if [ -f "${custom_job_runner}" ] ; then
+        # If there is a custom job runner, use it to run the job file. 
+        chmod +x "${custom_job_runner}"
+        "${custom_job_runner}" \
+            "${job_file}" \
+            "${output_dir}" \
+            "${cw_INSTANCE_role}" \
+            "${cw_CLUSTER_name}" \
+            ${ARGS}
+        exit_code=$?
+    else
+        # If there is not a custom job runner, try executing the job file.
+        chmod +x "${job_file}"
+        "${job_file}" "${cw_INSTANCE_role}" "${cw_CLUSTER_name}" ${ARGS}
+        exit_code=$?
+    fi
+    echo $exit_code > "${status_file}"
+    return $exit_code
+}
+
+
+job_queue_process_pending_jobs() {
+    local queue job_file job_id exit_code
+    local output_dir log_file status_file
+    local rejected_dir rejected_file
+    queue="$1"
+
+    echo "$( ls "$(job_queue_work_dir_path "${queue}" pending)" | wc -l ) pending job(s) found"
+    for job_id in $( ls -tr "$(job_queue_work_dir_path "${queue}" pending)" ) ; do
+        echo "Processing job ${job_id}"
+        job_file="$(job_queue_work_dir_path "${queue}" pending/${job_id})"
+
+        output_dir="$(job_queue_work_dir_path "${queue}" completed/${job_id}/$(hostname))"
+        log_file="${output_dir}"/logs
+        status_file="${output_dir}"/status
+
+        rejected_dir="$(job_queue_work_dir_path "${queue}" rejected/${job_id}/$(hostname))"
+        rejected_file="${rejected_dir}"/reason
+
+        # mark_job_file_as_in_progress
+
+        echo "Validating job ${job_id}"
+        job_queue_validate_job_id "${queue}" "${job_id}" $rejected_file
+        exit_code=$?
+        if [ $exit_code -eq 0 ] ; then
+            job_queue_validate_job_file "${queue}" $job_file $rejected_dir $rejected_file
+            exit_code=$?
+        fi
+        if [ $exit_code -ne 0 ] ; then
+            echo "Rejected job ${job_id}"
+            job_queue_save_job_output "${queue}" "${job_id}" rejected
+            job_queue_delete_job "${queue}" "${job_id}"
+        else
+            mkdir -p $(dirname $log_file)
+            job_queue_execute_job "${queue}" $job_file $status_file $output_dir >"${log_file}" 2>&1
+            exit_code=$?
+            if [ $exit_code -ne 0 ] ; then
+                echo "Error during execution of ${job_id}"
+            else
+                echo "Successfully executed job ${job_id}"
+            fi
+            job_queue_save_job_output "${queue}" "${job_id}" completed
+            job_queue_delete_job "${queue}" "${job_id}"
+        fi
+    done
+}
+
+job_queue_process_queues() {
+    local BUCKET WORK_DIR ARGS queue job_queues
+    ARGS="$@"
+    job_queues=()
+    WORK_DIR=$( mktemp -d -p /tmp cluster-job-queue.XXXXXXXXXXXX )
+
+    job_queue_s3cmd_setup
+    echo "Getting job queues"
+    job_queue_get_job_queues
+    echo "Found ${#job_queues[@]} job queues"
+    for queue in ${job_queues[@]}; do
+        echo "Processing cluster job queue ${queue}"
+        echo "Getting customization scripts for ${queue}"
+        job_queue_get_job_handling_customizations "${queue}"
+        echo "Getting pending jobs for ${queue}"
+        job_queue_get_pending_jobs "${queue}"
+        job_queue_process_pending_jobs "${queue}"
+    done
+
+    rm -rf "${WORK_DIR}"
+}
+
+job_queue_list_queues() {
+    local job_queues q queue
+    job_queues=()
+    queue="$1"
+
+    job_queue_get_job_queues
+    for q in ${job_queues[@]} ; do
+        echo $q
+    done
+}
+
+job_queue_list_jobs_in_queue() {
+    local queue job_status s3_prefix
+    queue="$1"
+    job_status="$2"
+
+    job_queue_s3cmd_setup
+    s3_prefix=$(job_queue_bucket_path "${queue}" "${job_status}"/ )
+
+    "${cw_ROOT}"/opt/s3cmd/s3cmd ls ${s3_prefix} \
+        | rev \
+        | cut -d/ -f1 \
+        | rev
+}
+
+job_queue_put() {
+    local queue job_file job_id s3_key
+    queue="$1"
+    job_file="$2"
+    job_id="$3"
+
+    job_queue_s3cmd_setup
+    s3_key=$(job_queue_bucket_path "${queue}" pending/"${job_id}" )
+
+    "${cw_ROOT}"/opt/s3cmd/s3cmd put --quiet ${job_file} ${s3_key}
+}
+
+job_queue_list_output_files() {
+    local queue job_id s3_key s3cmd_args job_status
+    queue="$1"
+    job_id="$2"
+
+    job_queue_s3cmd_setup
+    job_status=$(job_queue_get_job_status "${queue}" "${job_id}")
+    s3_key=$(job_queue_bucket_path "${queue}" "${job_status}"/"${job_id}"/ )
+
+    "${cw_ROOT}"/opt/s3cmd/s3cmd ls --recursive ${s3_key} \
+        | awk '{print $4}' \
+        | sed "s ${s3_key}  g"
+}
+
+job_queue_get_output_file() {
+    local queue job_id output_file job_status s3_key s3cmd_args
+    queue="$1"
+    job_id="$2"
+    output_file="$3"
+    s3cmd_args=(--quiet)
+
+    job_queue_s3cmd_setup
+    job_status=$(job_queue_get_job_status "${queue}" "${job_id}")
+    s3_key=$(job_queue_bucket_path "${queue}" "${job_status}"/"${job_id}"/"${output_file}" )
+
+    "${cw_ROOT}"/opt/s3cmd/s3cmd get ${s3cmd_args[@]} ${s3_key} -
+}
+
+job_queue_get_job_status() {
+    local queue job_id s3_key s3cmd_args
+    queue="$1"
+    job_id="$2"
+
+    job_queue_s3cmd_setup
+
+    s3_key=$(job_queue_bucket_path "${queue}" pending/"${job_id}" )
+    if [ $( "${cw_ROOT}"/opt/s3cmd/s3cmd ls ${s3_key} | wc -l ) -ne 0 ] ; then
+        echo "pending"
+        return 0
+    fi
+
+    s3_key=$(job_queue_bucket_path "${queue}" completed/"${job_id}" )
+    if [ $( "${cw_ROOT}"/opt/s3cmd/s3cmd ls ${s3_key} | wc -l ) -ne 0 ] ; then
+        echo "completed"
+        return 0
+    fi
+
+    s3_key=$(job_queue_bucket_path "${queue}" rejected/"${job_id}" )
+    if [ $( "${cw_ROOT}"/opt/s3cmd/s3cmd ls ${s3_key} | wc -l ) -ne 0 ] ; then
+        echo "rejected"
+        return 0
+    fi
+}
+
+job_queue_delete_job() {
+    local queue job_id s3_key s3cmd_args
+    queue="$1"
+    job_id="$2"
+
+    job_queue_s3cmd_setup
+    s3_key=$(job_queue_bucket_path "${queue}" pending/"${job_id}" )
+    "${cw_ROOT}"/opt/s3cmd/s3cmd rm --quiet ${s3_key}
+}

--- a/clusterware-customize/lib/functions/job-queue.functions.sh
+++ b/clusterware-customize/lib/functions/job-queue.functions.sh
@@ -98,7 +98,20 @@ job_queue_save_job_output() {
     job_id=$2
     output_dir=$3
 
-    "${cw_ROOT}"/opt/s3cmd/s3cmd put --quiet --recursive \
+    # python-magic isn't installed on our clusters by default and without it
+    # the results files are uploaded as binary/octet-stream, which breaks
+    # viewing the logs in a browser tab.
+    #
+    # Most of the files should be text/plain, so we use that as the default
+    # and try to get s3cmd to use the file extension for guessing others.
+    #
+    # Using `--no-mime-magic` prevents the logs from filling with warnings
+    # about python-magic not being available.
+
+    "${cw_ROOT}"/opt/s3cmd/s3cmd put --recursive \
+        --default-mime-type=text/plain \
+        --guess-mime-type \
+        --no-mime-magic \
         $(job_queue_work_dir_path "${queue}" "${output_dir}"/"${job_id}"/"$(hostname)") \
         $(job_queue_bucket_path "${queue}" "${output_dir}"/"${job_id}")/
 }

--- a/clusterware-customize/libexec/actions/customize
+++ b/clusterware-customize/libexec/actions/customize
@@ -1,0 +1,73 @@
+: '
+: NAME: customize
+: SYNOPSIS: Customize your compute environment
+: VERSION: 1.0.0
+: '
+#==============================================================================
+# Copyright (C) 2016 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+# vim: set filetype=sh :
+action=$1
+shift
+cw_BINNAME="${cw_BINNAME} $(basename "$0")"
+
+case $action in
+    h|he|hel|help)
+        exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/help "$@"
+        ;;
+    l|li|lis|list|ls)
+        exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/list "$@"
+        ;;
+    t|tr|tri|trig|trigg|trigge|trigger)
+        exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/trigger "$@"
+        ;;
+    p|pu|pul|pull)
+        exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/pull "$@"
+        ;;
+    av|ava|avai|avail)
+        exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/avail "$@"
+        ;;
+    ap|app|appl|apply)
+        exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/apply "$@"
+        ;;
+    jq|jobq|jobqu|jobque|jobqueu|jobqueue|job-q|job-qu|job-que|job-queu|job-queue)
+        exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/job-queue "$@"
+        ;;
+    *)
+        cat <<EOF
+Usage: $cw_BINNAME COMMAND [[OPTION]... [ARGS]]
+Customize your compute environment.
+
+Commands:
+EOF
+printf "    %-28s  %s\n" "$cw_BINNAME apply" "Download and install a customization profile."
+printf "    %-28s  %s\n" "$cw_BINNAME avail" "List available customization profiles."
+printf "    %-28s  %s\n" "$cw_BINNAME help" "More help about this command."
+printf "    %-28s  %s\n" "$cw_BINNAME job-queue" "Manage the cluster job queues"
+printf "    %-28s  %s\n" "$cw_BINNAME list" "List installed customization profiles."
+printf "    %-28s  %s\n" "$cw_BINNAME pull" "Pull updated customization actions from upstream."
+printf "    %-28s  %s\n" "$cw_BINNAME trigger" "Manually trigger customization actions."
+cat <<EOF
+
+Please report bugs to support@alces-software.com
+Alces Software home page: <http://alces-software.com>
+EOF
+esac

--- a/clusterware-customize/libexec/actions/customize
+++ b/clusterware-customize/libexec/actions/customize
@@ -51,6 +51,9 @@ case $action in
     jq|jobq|jobqu|jobque|jobqueu|jobqueue|job-q|job-qu|job-que|job-queu|job-queue)
         exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/job-queue "$@"
         ;;
+    mi|midx|makeidx|makeindex)
+        exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/makeindex "$@"
+        ;;
     *)
         cat <<EOF
 Usage: $cw_BINNAME COMMAND [[OPTION]... [ARGS]]

--- a/clusterware-customize/libexec/actions/customize
+++ b/clusterware-customize/libexec/actions/customize
@@ -39,8 +39,11 @@ case $action in
     t|tr|tri|trig|trigg|trigge|trigger)
         exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/trigger "$@"
         ;;
-    p|pu|pul|pull)
+    pul|pull)
         exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/pull "$@"
+        ;;
+    pus|push)
+        exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/push "$@"
         ;;
     av|ava|avai|avail)
         exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/avail "$@"
@@ -67,6 +70,7 @@ printf "    %-28s  %s\n" "$cw_BINNAME help" "More help about this command."
 printf "    %-28s  %s\n" "$cw_BINNAME job-queue" "Manage the cluster job queues"
 printf "    %-28s  %s\n" "$cw_BINNAME list" "List installed customization profiles."
 printf "    %-28s  %s\n" "$cw_BINNAME pull" "Pull updated customization actions from upstream."
+printf "    %-28s  %s\n" "$cw_BINNAME push" "Push a customization profile to an upstream repository."
 printf "    %-28s  %s\n" "$cw_BINNAME trigger" "Manually trigger customization actions."
 cat <<EOF
 

--- a/clusterware-customize/libexec/customize/actions/apply
+++ b/clusterware-customize/libexec/customize/actions/apply
@@ -35,17 +35,17 @@ require network
 process_reexec_sudo "$@"
 
 main() {
-  local type profile_name nodes
+  local repo_name profile_name nodes
 
   if [ "$1" == "-n" ]; then
       nodes="$2"
       shift 2
   fi
 
-  type=${1%%/*}
+  repo_name=${1%%/*}
   profile_name=${1##*/}
-  if [[ "$type" == "$profile_name" ]]; then
-    echo "Incorrect format for customization profile: $type"
+  if [[ "$repo_name" == "$profile_name" ]]; then
+    echo "Incorrect format for customization profile: $repo_name. Please specify as 'repository-name/profile-name'."
     return 1
   fi
 
@@ -55,13 +55,7 @@ main() {
       ssh $node 'alces handler enable cluster-customizer; alces service install s3cmd; alces customize apply "'$1'"' < /dev/null
     done
   else
-    if [[ "$type" == "feature" ]]; then
-      customize_apply_feature "$profile_name"
-    elif [[ "$type" == "profile" ]]; then
-      customize_apply_profile "$profile_name"
-    else
-      echo "Unknown customization type: $type"
-    fi
+    customize_apply "$repo_name" "$profile_name"
   fi
 }
 

--- a/clusterware-customize/libexec/customize/actions/apply
+++ b/clusterware-customize/libexec/customize/actions/apply
@@ -26,6 +26,7 @@
 #ALCES_META_END
 
 require action
+require customize
 require handler
 require process
 require member
@@ -64,19 +65,12 @@ main() {
   fi
 }
 
-if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
-    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
-    require customize
+if network_has_metadata_service 1; then
+    files_load_config cluster-customizer
+    cw_CLUSTER_CUSTOMIZER_path="${cw_CLUSTER_CUSTOMIZER_path:-${cw_ROOT}/var/lib/customizer}"
+    cw_CLUSTER_CUSTOMIZER_profiles="${cw_CLUSTER_CUSTOMIZER_profiles:-default}"
 
-    if network_has_metadata_service 1; then
-        files_load_config cluster-customizer
-        cw_CLUSTER_CUSTOMIZER_path="${cw_CLUSTER_CUSTOMIZER_path:-${cw_ROOT}/var/lib/customizer}"
-        cw_CLUSTER_CUSTOMIZER_profiles="${cw_CLUSTER_CUSTOMIZER_profiles:-default}"
-
-        main "$@"
-    else
-        action_die 'unable to apply: no cloud metadata service detected'
-    fi
+    main "$@"
 else
-    action_die 'cluster-customizer handler is not enabled'
+    action_die 'unable to apply: no cloud metadata service detected'
 fi

--- a/clusterware-customize/libexec/customize/actions/apply
+++ b/clusterware-customize/libexec/customize/actions/apply
@@ -43,7 +43,7 @@ main() {
   fi
 
   repo_name=${1%%/*}
-  profile_name=${1##*/}
+  profile_name=${1#*/}
   if [[ "$repo_name" == "$profile_name" ]]; then
     echo "Incorrect format for customization profile: $repo_name. Please specify as 'repository-name/profile-name'."
     return 1

--- a/clusterware-customize/libexec/customize/actions/apply
+++ b/clusterware-customize/libexec/customize/actions/apply
@@ -1,0 +1,82 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2016 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+#ALCES_META
+# Refer to `clusterware/scripts/development/propagate`.
+#path=/opt/clusterware/libexec/customize/actions/apply
+#ALCES_META_END
+
+require action
+require handler
+require process
+require member
+require network
+
+process_reexec_sudo "$@"
+
+main() {
+  local type profile_name nodes
+
+  if [ "$1" == "-n" ]; then
+      nodes="$2"
+      shift 2
+  fi
+
+  type=${1%%/*}
+  profile_name=${1##*/}
+  if [[ "$type" == "$profile_name" ]]; then
+    echo "Incorrect format for customization profile: $type"
+    return 1
+  fi
+
+  if [[ "$nodes" ]]; then
+    echo $nodes | tr ',' '\n' | while read node; do
+      echo "Applying $1 to node $node..."
+      ssh $node 'alces handler enable cluster-customizer; alces service install s3cmd; alces customize apply "'$1'"' < /dev/null
+    done
+  else
+    if [[ "$type" == "feature" ]]; then
+      customize_apply_feature "$profile_name"
+    elif [[ "$type" == "profile" ]]; then
+      customize_apply_profile "$profile_name"
+    else
+      echo "Unknown customization type: $type"
+    fi
+  fi
+}
+
+if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
+    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
+    require customize
+
+    if network_has_metadata_service 1; then
+        files_load_config cluster-customizer
+        cw_CLUSTER_CUSTOMIZER_path="${cw_CLUSTER_CUSTOMIZER_path:-${cw_ROOT}/var/lib/customizer}"
+        cw_CLUSTER_CUSTOMIZER_profiles="${cw_CLUSTER_CUSTOMIZER_profiles:-default}"
+
+        main "$@"
+    else
+        action_die 'unable to apply: no cloud metadata service detected'
+    fi
+else
+    action_die 'cluster-customizer handler is not enabled'
+fi

--- a/clusterware-customize/libexec/customize/actions/apply
+++ b/clusterware-customize/libexec/customize/actions/apply
@@ -62,7 +62,7 @@ main() {
 if network_has_metadata_service 1; then
     files_load_config cluster-customizer
     cw_CLUSTER_CUSTOMIZER_path="${cw_CLUSTER_CUSTOMIZER_path:-${cw_ROOT}/var/lib/customizer}"
-    cw_CLUSTER_CUSTOMIZER_profiles="${cw_CLUSTER_CUSTOMIZER_profiles:-default}"
+    cw_CLUSTER_CUSTOMIZER_account_profiles="${cw_CLUSTER_CUSTOMIZER_account_profiles:-default}"
 
     main "$@"
 else

--- a/clusterware-customize/libexec/customize/actions/avail
+++ b/clusterware-customize/libexec/customize/actions/avail
@@ -37,7 +37,7 @@ if network_has_metadata_service 1; then
     files_load_config cluster-customizer
     cw_CLUSTER_CUSTOMIZER_path="${cw_CLUSTER_CUSTOMIZER_path:-${cw_ROOT}/var/lib/customizer}"
     cw_CLUSTER_CUSTOMIZER_profiles="${cw_CLUSTER_CUSTOMIZER_profiles:-default}"
-    customize_list
+    customize_list "$@"
 else
     action_die 'unable to list: no cloud metadata service detected'
 fi

--- a/clusterware-customize/libexec/customize/actions/avail
+++ b/clusterware-customize/libexec/customize/actions/avail
@@ -1,0 +1,49 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2016 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+#ALCES_META
+# Refer to `clusterware/scripts/development/propagate`.
+#path=/opt/clusterware/libexec/customize/actions/avail
+#ALCES_META_END
+
+require action
+require handler
+require network
+require process
+
+process_reexec_sudo "$@"
+
+if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
+    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
+    require customize
+
+    if network_has_metadata_service 1; then
+        files_load_config cluster-customizer
+        cw_CLUSTER_CUSTOMIZER_path="${cw_CLUSTER_CUSTOMIZER_path:-${cw_ROOT}/var/lib/customizer}"
+        cw_CLUSTER_CUSTOMIZER_profiles="${cw_CLUSTER_CUSTOMIZER_profiles:-default}"
+        customize_list
+    else
+        action_die 'unable to pull: no cloud metadata service detected'
+    fi
+else
+    action_die 'cluster-customizer handler is not enabled'
+fi

--- a/clusterware-customize/libexec/customize/actions/avail
+++ b/clusterware-customize/libexec/customize/actions/avail
@@ -36,7 +36,7 @@ process_reexec_sudo "$@"
 if network_has_metadata_service 1; then
     files_load_config cluster-customizer
     cw_CLUSTER_CUSTOMIZER_path="${cw_CLUSTER_CUSTOMIZER_path:-${cw_ROOT}/var/lib/customizer}"
-    cw_CLUSTER_CUSTOMIZER_profiles="${cw_CLUSTER_CUSTOMIZER_profiles:-default}"
+    cw_CLUSTER_CUSTOMIZER_account_profiles="${cw_CLUSTER_CUSTOMIZER_account_profiles:-default}"
     customize_avail "$@"
 else
     action_die 'unable to list: no cloud metadata service detected'

--- a/clusterware-customize/libexec/customize/actions/avail
+++ b/clusterware-customize/libexec/customize/actions/avail
@@ -37,7 +37,7 @@ if network_has_metadata_service 1; then
     files_load_config cluster-customizer
     cw_CLUSTER_CUSTOMIZER_path="${cw_CLUSTER_CUSTOMIZER_path:-${cw_ROOT}/var/lib/customizer}"
     cw_CLUSTER_CUSTOMIZER_profiles="${cw_CLUSTER_CUSTOMIZER_profiles:-default}"
-    customize_list "$@"
+    customize_avail "$@"
 else
     action_die 'unable to list: no cloud metadata service detected'
 fi

--- a/clusterware-customize/libexec/customize/actions/avail
+++ b/clusterware-customize/libexec/customize/actions/avail
@@ -26,24 +26,18 @@
 #ALCES_META_END
 
 require action
+require customize
 require handler
 require network
 require process
 
 process_reexec_sudo "$@"
 
-if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
-    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
-    require customize
-
-    if network_has_metadata_service 1; then
-        files_load_config cluster-customizer
-        cw_CLUSTER_CUSTOMIZER_path="${cw_CLUSTER_CUSTOMIZER_path:-${cw_ROOT}/var/lib/customizer}"
-        cw_CLUSTER_CUSTOMIZER_profiles="${cw_CLUSTER_CUSTOMIZER_profiles:-default}"
-        customize_list
-    else
-        action_die 'unable to pull: no cloud metadata service detected'
-    fi
+if network_has_metadata_service 1; then
+    files_load_config cluster-customizer
+    cw_CLUSTER_CUSTOMIZER_path="${cw_CLUSTER_CUSTOMIZER_path:-${cw_ROOT}/var/lib/customizer}"
+    cw_CLUSTER_CUSTOMIZER_profiles="${cw_CLUSTER_CUSTOMIZER_profiles:-default}"
+    customize_list
 else
-    action_die 'cluster-customizer handler is not enabled'
+    action_die 'unable to list: no cloud metadata service detected'
 fi

--- a/clusterware-customize/libexec/customize/actions/help
+++ b/clusterware-customize/libexec/customize/actions/help
@@ -1,0 +1,184 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2016 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+require action
+
+main() {
+    action=$1
+    shift
+
+    case $action in
+        apply|avail|help|job-queue|list|trigger|pull)
+            help_for_${action}
+            ;;
+        ?*)
+            echo "${cw_BINNAME}: no such topic: ${action}"
+            echo ""
+            general_help
+            ;;
+        *)
+            general_help
+            ;;
+    esac
+}
+
+help_for_apply() {
+    cat <<EOF
+  SYNOPSIS:
+
+    alces customize apply [OPTIONS] <profile>
+
+  DESCRIPTION:
+
+    Download and install a customization <profile> to the current
+    node or, optionally, a list of other nodes in the cluster.
+
+    A list of available customization profiles can be shown by
+    running "alces customize avail".
+
+    Once downloaded, the customization will have its configure event
+    triggered, along with a member-join event for each current member
+    of the cluster.
+
+  OPTIONS:
+
+    -n <node list>
+      You may specify a comma-separated list of nodes on which the
+      customization profile should be installed. When this option is
+      specified the customization will not be applied to the current
+      node, unless it appears in the <node list>.
+
+EOF
+}
+
+help_for_avail() {
+  cat <<EOF
+SYNOPSIS:
+
+  alces customize avail
+
+DESCRIPTION:
+
+  List customization profiles that are available but not installed.
+
+EOF
+}
+
+help_for_help() {
+    cat <<EOF
+  SYNOPSIS:
+
+    alces customize help [<command>]
+
+  DESCRIPTION:
+
+    Get help with customize commands.  If no <command> is specified,
+    show some general help.
+
+EOF
+}
+
+help_for_job-queue() {
+    exec "${cw_ROOT}"/bin/alces customize job-queue help
+}
+
+help_for_list() {
+    cat <<EOF
+  SYNOPSIS:
+
+    alces handler list [OPTIONS]
+
+  DESCRIPTION:
+
+    Display currently installed customization profiles.
+
+  OPTIONS:
+
+    --with-events
+      Also show which events each profile supports.
+
+EOF
+}
+
+help_for_pull() {
+    cat <<EOF
+  SYNOPSIS:
+
+    alces customize pull
+
+  DESCRIPTION:
+
+    Pull customization profiles from upstream bucket(s).
+
+EOF
+}
+
+help_for_trigger() {
+    cat <<EOF
+  SYNOPSIS:
+
+    alces customize trigger [OPTIONS] <event> [<profile>]
+
+  DESCRIPTION:
+
+    Trigger the specified customization <event>.  Optionally specify a
+    specific <profile> for which you want to trigger the <event>.
+
+  OPTIONS:
+
+    -m <member list>
+      For the 'member-join' <event> you may specify a comma-separated
+      list of member names for which the event should be triggered.
+
+EOF
+}
+
+general_help() {
+    local binname
+    binname="${cw_BINNAME% *}"
+    cat <<EOF
+  NAME:
+
+    ${binname}
+
+  DESCRIPTION:
+
+    Customize your compute environment
+
+  COMMANDS:
+
+EOF
+printf "    %-28s  %s\n" "$cw_BINNAME apply" "Download and install a customization profile."
+printf "    %-28s  %s\n" "$cw_BINNAME avail" "List available customization profiles."
+printf "    %-28s  %s\n" "$cw_BINNAME help" "More help about this command."
+printf "    %-28s  %s\n" "$cw_BINNAME job-queue" "Manage the Alces cluster job queue"
+printf "    %-28s  %s\n" "$cw_BINNAME list" "List installed customization profiles."
+printf "    %-28s  %s\n" "$cw_BINNAME pull" "Pull updated customization actions from upstream."
+printf "    %-28s  %s\n" "$cw_BINNAME trigger" "Manually trigger customization actions."
+cat <<EOF
+
+Please report bugs to support@alces-software.com
+Alces Software home page: <http://alces-software.com>
+EOF
+}
+
+main "$@"

--- a/clusterware-customize/libexec/customize/actions/job-queue
+++ b/clusterware-customize/libexec/customize/actions/job-queue
@@ -1,0 +1,77 @@
+: '
+: NAME: job-queue
+: SYNOPSIS: Manage the Alces cluster job queue
+: VERSION: 1.0.0
+: '
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+# vim: set filetype=sh :
+action=$1
+shift
+cw_BINNAME="${cw_BINNAME} $(basename "$0")"
+
+case $action in
+    h|he|hel|help)
+        exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/job-queue-actions/help "$@"
+        ;;
+    lj|listjobs|list-jobs|ls-jobs|lsjobs)
+        exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/job-queue-actions/list-jobs "$@"
+        ;;
+    lo|listoutput|list-output|ls-output|lsoutput)
+        exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/job-queue-actions/list-output "$@"
+        ;;
+    lq|listqueues|list-queues|ls-queues|lsqueues)
+        exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/job-queue-actions/list-queues "$@"
+        ;;
+    p|pu|put)
+        exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/job-queue-actions/put "$@"
+        ;;
+    go|goutput|getoutput|get-output)
+        exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/job-queue-actions/get-output "$@"
+        ;;
+    rm|remove)
+        exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/job-queue-actions/rm "$@"
+        ;;
+    s|st|sta|stat|statu|status)
+        exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/job-queue-actions/status "$@"
+        ;;
+    *)
+        cat <<EOF
+Usage: $cw_BINNAME COMMAND [[OPTION]... [ARGS]]
+Manage the Alces cluster job queue
+
+Commands:
+EOF
+printf "    %-28s  %s\n" "$cw_BINNAME get-output" "Get output for a job."
+printf "    %-28s  %s\n" "$cw_BINNAME help" "More help about this command."
+printf "    %-28s  %s\n" "$cw_BINNAME list-jobs" "List pending jobs for a queue."
+printf "    %-28s  %s\n" "$cw_BINNAME list-output" "List output files for a job."
+printf "    %-28s  %s\n" "$cw_BINNAME list-queues" "List current queues."
+printf "    %-28s  %s\n" "$cw_BINNAME put" "Put a job into a queue."
+printf "    %-28s  %s\n" "$cw_BINNAME rm" "Remove a pending job from a queue."
+printf "    %-28s  %s\n" "$cw_BINNAME status" "Get the status of a job."
+cat <<EOF
+
+Please report bugs to support@alces-software.com
+Alces Software home page: <http://alces-software.com>
+EOF
+esac

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/get-output
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/get-output
@@ -22,6 +22,7 @@
 #==============================================================================
 require action
 require handler
+require job-queue
 
 main() {
     local queue job_file job_id output_file
@@ -36,11 +37,4 @@ main() {
     job_queue_get_output_file "${queue}" "${job_id}" "${output_file}"
 }
 
-if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
-    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
-    require job-queue
-
-    main "$@"
-else
-    action_die 'cluster-customizer handler is not enabled'
-fi
+main "$@"

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/get-output
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/get-output
@@ -22,6 +22,7 @@
 #==============================================================================
 require action
 require handler
+require process
 require job-queue
 
 main() {
@@ -37,4 +38,5 @@ main() {
     job_queue_get_output_file "${queue}" "${job_id}" "${output_file}"
 }
 
+process_reexec_sudo "$@"
 main "$@"

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/get-output
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/get-output
@@ -1,0 +1,46 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+require action
+require handler
+
+main() {
+    local queue job_file job_id output_file
+    queue="$1"
+    job_id="$2"
+    output_file="$3"
+
+    if [ -z "${queue}" -o -z "${job_id}" -o -z "${output_file}" ] ; then
+        action_die "usage: ${cw_BINNAME} [OPTIONS] <queue> <job_id> <output_file>"
+    fi
+
+    job_queue_get_output_file "${queue}" "${job_id}" "${output_file}"
+}
+
+if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
+    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
+    require job-queue
+
+    main "$@"
+else
+    action_die 'cluster-customizer handler is not enabled'
+fi

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/help
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/help
@@ -1,0 +1,181 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+require action
+
+main() {
+    action=$1
+    shift
+
+
+    case $action in
+        get-output|help|list-jobs|list-output|list-queues|put|rm|status)
+            help_for_${action}
+            ;;
+        ?*)
+            echo "${cw_BINNAME}: no such topic: ${action}"
+            echo ""
+            general_help
+            ;;
+        *)
+            general_help
+            ;;
+    esac
+}
+
+help_for_get-output() {
+    cat <<EOF
+  SYNOPSIS:
+
+    alces customize job-queue get-output <queue> <job_id> <output_file>
+
+  DESCRIPTION:
+
+    Display the contents of output file <output_file> for job <job_id> in the
+    queue <queue>.
+
+EOF
+}
+
+help_for_help() {
+    cat <<EOF
+  SYNOPSIS:
+
+    alces customize job-queue help [<command>]
+
+  DESCRIPTION:
+
+    Get help with job-queue commands.  If no <command> is specified,
+    show some general help.
+
+EOF
+}
+
+help_for_list-jobs() {
+    cat <<EOF
+  SYNOPSIS:
+
+    alces customize job-queue list-jobs <queue>
+
+  DESCRIPTION:
+
+    List pending jobs in the given <queue>.
+
+EOF
+}
+
+help_for_list-output() {
+    cat <<EOF
+  SYNOPSIS:
+
+    alces customize job-queue list-output <queue>
+
+  DESCRIPTION:
+
+    List output files for <job_id> in <queue>.
+
+EOF
+}
+
+help_for_list-queues() {
+    cat <<EOF
+  SYNOPSIS:
+
+    alces customize job-queue list-queues
+
+  DESCRIPTION:
+
+    List current queues.
+
+EOF
+}
+
+help_for_put() {
+    cat <<EOF
+  SYNOPSIS:
+
+    alces customize job-queue put <queue> <FILE>
+
+  DESCRIPTION:
+
+    Put the <FILE> into the job queue <queue>.
+
+EOF
+}
+
+help_for_rm() {
+    cat <<EOF
+  SYNOPSIS:
+
+    alces customize job-queue rm <queue> <job_id>
+
+  DESCRIPTION:
+
+    Remove the pending job <job_id> from queue <queue>.
+
+EOF
+}
+
+help_for_status() {
+    cat <<EOF
+  SYNOPSIS:
+
+    alces customize job-queue status <queue> <job_id>
+
+  DESCRIPTION:
+
+    Get the status of the job <job_id> in queue <queue>.
+
+EOF
+}
+
+general_help() {
+    local binname
+    binname="${cw_BINNAME% *}"
+    cat <<EOF
+  NAME:
+
+    ${binname}
+
+  DESCRIPTION:
+
+    Manage the Alces cluster job queue
+
+  COMMANDS:
+
+EOF
+printf "    %-28s  %s\n" "$cw_BINNAME get-output" "Get output for a job."
+printf "    %-28s  %s\n" "$cw_BINNAME help" "More help about this command."
+printf "    %-28s  %s\n" "$cw_BINNAME list-jobs" "List pending jobs for a queue."
+printf "    %-28s  %s\n" "$cw_BINNAME list-output" "List output files for a job."
+printf "    %-28s  %s\n" "$cw_BINNAME list-queues" "List current queues."
+printf "    %-28s  %s\n" "$cw_BINNAME put" "Put a job into a queue."
+printf "    %-28s  %s\n" "$cw_BINNAME rm" "Remove a pending job from a queue."
+printf "    %-28s  %s\n" "$cw_BINNAME status" "Get the status of a job."
+cat <<EOF
+
+Please report bugs to support@alces-software.com
+Alces Software home page: <http://alces-software.com>
+EOF
+}
+
+main "$@"

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/list-jobs
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/list-jobs
@@ -22,6 +22,7 @@
 #==============================================================================
 require action
 require handler
+require process
 require job-queue
 
 main() {
@@ -35,4 +36,5 @@ main() {
     job_queue_list_jobs_in_queue "${queue}" "pending"
 }
 
+process_reexec_sudo "$@"
 main "$@"

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/list-jobs
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/list-jobs
@@ -1,0 +1,44 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+require action
+require handler
+
+main() {
+    local queue
+    queue="$1"
+
+    if [ -z "${queue}" ] ; then
+        action_die "usage: ${cw_BINNAME} <queue>"
+    fi
+
+    job_queue_list_jobs_in_queue "${queue}" "pending"
+}
+
+if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
+    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
+    require job-queue
+
+    main "$@"
+else
+    action_die 'cluster-customizer handler is not enabled'
+fi

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/list-jobs
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/list-jobs
@@ -22,6 +22,7 @@
 #==============================================================================
 require action
 require handler
+require job-queue
 
 main() {
     local queue
@@ -34,11 +35,4 @@ main() {
     job_queue_list_jobs_in_queue "${queue}" "pending"
 }
 
-if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
-    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
-    require job-queue
-
-    main "$@"
-else
-    action_die 'cluster-customizer handler is not enabled'
-fi
+main "$@"

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/list-output
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/list-output
@@ -1,0 +1,45 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+require action
+require handler
+
+main() {
+    local queue job_id
+    queue="$1"
+    job_id="$2"
+
+    if [ -z "${queue}" -o -z "${job_id}" ] ; then
+        action_die "usage: ${cw_BINNAME} <queue> <job_id>"
+    fi
+
+    job_queue_list_output_files "${queue}" "${job_id}"
+}
+
+if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
+    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
+    require job-queue
+
+    main "$@"
+else
+    action_die 'cluster-customizer handler is not enabled'
+fi

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/list-output
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/list-output
@@ -22,6 +22,7 @@
 #==============================================================================
 require action
 require handler
+require process
 require job-queue
 
 main() {
@@ -36,4 +37,5 @@ main() {
     job_queue_list_output_files "${queue}" "${job_id}"
 }
 
+process_reexec_sudo "$@"
 main "$@"

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/list-output
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/list-output
@@ -22,6 +22,7 @@
 #==============================================================================
 require action
 require handler
+require job-queue
 
 main() {
     local queue job_id
@@ -35,11 +36,4 @@ main() {
     job_queue_list_output_files "${queue}" "${job_id}"
 }
 
-if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
-    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
-    require job-queue
-
-    main "$@"
-else
-    action_die 'cluster-customizer handler is not enabled'
-fi
+main "$@"

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/list-queues
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/list-queues
@@ -22,6 +22,8 @@
 #==============================================================================
 require action
 require handler
+require process
 require job-queue
 
+process_reexec_sudo "$@"
 job_queue_list_queues "$@"

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/list-queues
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/list-queues
@@ -1,0 +1,34 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+require action
+require handler
+
+if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
+    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
+    require job-queue
+
+    job_queue_list_queues "$@"
+else
+    action_die 'cluster-customizer handler is not enabled'
+fi
+

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/list-queues
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/list-queues
@@ -22,13 +22,6 @@
 #==============================================================================
 require action
 require handler
+require job-queue
 
-if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
-    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
-    require job-queue
-
-    job_queue_list_queues "$@"
-else
-    action_die 'cluster-customizer handler is not enabled'
-fi
-
+job_queue_list_queues "$@"

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/put
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/put
@@ -22,6 +22,7 @@
 #==============================================================================
 require action
 require handler
+require process
 require job-queue
 
 main() {
@@ -44,4 +45,5 @@ main() {
     echo "${job_id}"
 }
 
+process_reexec_sudo "$@"
 main "$@"

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/put
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/put
@@ -1,0 +1,53 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+require action
+require handler
+
+main() {
+    local queue job_file job_id
+    queue="$1"
+    job_file="$2"
+    job_id="$3"
+
+    if [ -z "${queue}" -o -z "${job_file}" ] ; then
+        action_die "usage: ${cw_BINNAME} <queue> <FILE>"
+    fi
+    if [ ! -r "${job_file}" ] ; then
+        action_die "${cw_BINNAME} cannot access ${job_file}: No such file"
+    fi
+    if [ -z "${job_id}" ] ; then
+        job_id="$(uuidgen)"
+    fi
+
+    job_queue_put "${queue}" "${job_file}" "${job_id}"
+    echo "${job_id}"
+}
+
+if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
+    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
+    require job-queue
+
+    main "$@"
+else
+    action_die 'cluster-customizer handler is not enabled'
+fi

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/put
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/put
@@ -22,6 +22,7 @@
 #==============================================================================
 require action
 require handler
+require job-queue
 
 main() {
     local queue job_file job_id
@@ -43,11 +44,4 @@ main() {
     echo "${job_id}"
 }
 
-if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
-    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
-    require job-queue
-
-    main "$@"
-else
-    action_die 'cluster-customizer handler is not enabled'
-fi
+main "$@"

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/rm
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/rm
@@ -22,6 +22,7 @@
 #==============================================================================
 require action
 require handler
+require job-queue
 
 main() {
     local queue job_id
@@ -35,11 +36,4 @@ main() {
     job_queue_delete_job "${queue}" "${job_id}"
 }
 
-if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
-    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
-    require job-queue
-
-    main "$@"
-else
-    action_die 'cluster-customizer handler is not enabled'
-fi
+main "$@"

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/rm
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/rm
@@ -22,6 +22,7 @@
 #==============================================================================
 require action
 require handler
+require process
 require job-queue
 
 main() {
@@ -36,4 +37,5 @@ main() {
     job_queue_delete_job "${queue}" "${job_id}"
 }
 
+process_reexec_sudo "$@"
 main "$@"

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/rm
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/rm
@@ -1,0 +1,45 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+require action
+require handler
+
+main() {
+    local queue job_id
+    queue="$1"
+    job_id="$2"
+
+    if [ -z "${queue}" -o -z "${job_id}" ] ; then
+        action_die "usage: ${cw_BINNAME} <queue> <job_id>"
+    fi
+
+    job_queue_delete_job "${queue}" "${job_id}"
+}
+
+if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
+    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
+    require job-queue
+
+    main "$@"
+else
+    action_die 'cluster-customizer handler is not enabled'
+fi

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/status
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/status
@@ -1,0 +1,46 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+require action
+require handler
+
+main() {
+    local queue job_id
+    queue="$1"
+    job_id="$2"
+
+    if [ -z "${queue}" -o -z "${job_id}" ] ; then
+        action_die "usage: ${cw_BINNAME} <queue> <job_id>"
+    fi
+
+    job_queue_get_job_status "${queue}" "${job_id}"
+}
+
+if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
+    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
+    require job-queue
+
+    main "$@"
+else
+    action_die 'cluster-customizer handler is not enabled'
+fi
+

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/status
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/status
@@ -22,6 +22,7 @@
 #==============================================================================
 require action
 require handler
+require job-queue
 
 main() {
     local queue job_id
@@ -35,12 +36,4 @@ main() {
     job_queue_get_job_status "${queue}" "${job_id}"
 }
 
-if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
-    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
-    require job-queue
-
-    main "$@"
-else
-    action_die 'cluster-customizer handler is not enabled'
-fi
-
+main "$@"

--- a/clusterware-customize/libexec/customize/actions/job-queue-actions/status
+++ b/clusterware-customize/libexec/customize/actions/job-queue-actions/status
@@ -22,6 +22,7 @@
 #==============================================================================
 require action
 require handler
+require process
 require job-queue
 
 main() {
@@ -36,4 +37,5 @@ main() {
     job_queue_get_job_status "${queue}" "${job_id}"
 }
 
+process_reexec_sudo "$@"
 main "$@"

--- a/clusterware-customize/libexec/customize/actions/list
+++ b/clusterware-customize/libexec/customize/actions/list
@@ -1,0 +1,33 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2016 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+require action
+require handler
+
+if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
+    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
+    require customize
+
+    customize_list_hooks "$@"
+else
+    action_die 'cluster-customizer handler is not enabled'
+fi

--- a/clusterware-customize/libexec/customize/actions/list
+++ b/clusterware-customize/libexec/customize/actions/list
@@ -21,13 +21,7 @@
 # https://github.com/alces-software/clusterware
 #==============================================================================
 require action
+require customize
 require handler
 
-if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
-    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
-    require customize
-
-    customize_list_hooks "$@"
-else
-    action_die 'cluster-customizer handler is not enabled'
-fi
+customize_list_hooks "$@"

--- a/clusterware-customize/libexec/customize/actions/makeindex
+++ b/clusterware-customize/libexec/customize/actions/makeindex
@@ -1,0 +1,49 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+
+require ruby
+
+ruby_run <<RUBY
+
+require 'yaml'
+
+rootDir = "$1"
+
+profiles = {}
+
+Dir.entries(rootDir).select {|f| !File.directory? f}.each do |profile_name|
+  manifest_file = File.expand_path("#{profile_name}/manifest.txt", rootDir)
+
+  if File.exists?(manifest_file)
+    manifest = File.read(manifest_file).split("\n")
+    profiles[profile_name] = { 'manifest' => manifest }
+  end
+end
+
+index = {'profiles' => profiles}
+
+File.open(File.expand_path('index.yml', rootDir), 'w') { |outFile|
+  outFile.write index.to_yaml
+}
+
+RUBY

--- a/clusterware-customize/libexec/customize/actions/makeindex
+++ b/clusterware-customize/libexec/customize/actions/makeindex
@@ -33,10 +33,20 @@ profiles = {}
 
 Dir.entries(rootDir).select {|f| !File.directory? f}.each do |profile_name|
   manifest_file = File.expand_path("#{profile_name}/manifest.txt", rootDir)
+  tags_file = File.expand_path("#{profile_name}/tags.txt", rootDir)
 
   if File.exists?(manifest_file)
+    profile = {}
+
     manifest = File.read(manifest_file).split("\n")
-    profiles[profile_name] = { 'manifest' => manifest }
+    profile['manifest'] = manifest
+
+    if File.exists(tags_file)
+      tags = File.read(tags_file).split("\n")
+      profile['tags'] = tags
+    end
+
+    profiles[profile_name] = profile
   end
 end
 
@@ -45,5 +55,4 @@ index = {'profiles' => profiles}
 File.open(File.expand_path('index.yml', rootDir), 'w') { |outFile|
   outFile.write index.to_yaml
 }
-
 RUBY

--- a/clusterware-customize/libexec/customize/actions/makeindex
+++ b/clusterware-customize/libexec/customize/actions/makeindex
@@ -41,9 +41,22 @@ Dir.entries(rootDir).select {|f| !File.directory? f}.each do |profile_name|
     manifest = File.read(manifest_file).split("\n")
     profile['manifest'] = manifest
 
-    if File.exists(tags_file)
+    if File.exists?(tags_file)
       tags = File.read(tags_file).split("\n")
       profile['tags'] = tags
+    end
+
+    if Dir.exists?("#{rootDir}/#{profile_name}/initialize.d") || Dir.exists?("#{rootDir}/#{profile_name}/preconfigure.d")
+      # Automagically tag profile as startup
+      if !profile.key?('tags')
+        profile['tags'] = []
+        File.write(tags_file, "startup\n")
+      end
+      if !profile['tags'].include?('startup')
+        # tags were specified but pre-init was not. We should fix that:
+        File.open(tags_file, 'a') { |f| f.write("startup\n") }
+        profile['tags'] << 'startup'
+      end
     end
 
     profiles[profile_name] = profile
@@ -55,4 +68,5 @@ index = {'profiles' => profiles}
 File.open(File.expand_path('index.yml', rootDir), 'w') { |outFile|
   outFile.write index.to_yaml
 }
+
 RUBY

--- a/clusterware-customize/libexec/customize/actions/makeindex
+++ b/clusterware-customize/libexec/customize/actions/makeindex
@@ -21,52 +21,14 @@
 # https://github.com/alces-software/clusterware
 #==============================================================================
 
-require ruby
+require customize-repository
 
-ruby_run <<RUBY
+index_file="${1}/index.yml"
 
-require 'yaml'
-
-rootDir = "$1"
-
-profiles = {}
-
-Dir.entries(rootDir).select {|f| !File.directory? f}.each do |profile_name|
-  manifest_file = File.expand_path("#{profile_name}/manifest.txt", rootDir)
-  tags_file = File.expand_path("#{profile_name}/tags.txt", rootDir)
-
-  if File.exists?(manifest_file)
-    profile = {}
-
-    manifest = File.read(manifest_file).split("\n")
-    profile['manifest'] = manifest
-
-    if File.exists?(tags_file)
-      tags = File.read(tags_file).split("\n")
-      profile['tags'] = tags
-    end
-
-    if Dir.exists?("#{rootDir}/#{profile_name}/initialize.d") || Dir.exists?("#{rootDir}/#{profile_name}/preconfigure.d")
-      # Automagically tag profile as startup
-      if !profile.key?('tags')
-        profile['tags'] = []
-        File.write(tags_file, "startup\n")
-      end
-      if !profile['tags'].include?('startup')
-        # tags were specified but pre-init was not. We should fix that:
-        File.open(tags_file, 'a') { |f| f.write("startup\n") }
-        profile['tags'] << 'startup'
-      end
-    end
-
-    profiles[profile_name] = profile
-  end
-end
-
-index = {'profiles' => profiles}
-
-File.open(File.expand_path('index.yml', rootDir), 'w') { |outFile|
-  outFile.write index.to_yaml
-}
-
-RUBY
+for profile_dir in "$1"/*; do
+ if [[ -d "$profile_dir" ]]; then
+   profile_name=$(basename "$profile_dir")
+   print "$profile_name"
+   customize_repository_add_to_index "$index_file" "$profile_dir" "$profile_name"
+ fi
+done

--- a/clusterware-customize/libexec/customize/actions/pull
+++ b/clusterware-customize/libexec/customize/actions/pull
@@ -31,7 +31,7 @@ process_reexec_sudo "$@"
 if network_has_metadata_service 1; then
     files_load_config cluster-customizer
     cw_CLUSTER_CUSTOMIZER_path="${cw_CLUSTER_CUSTOMIZER_path:-${cw_ROOT}/var/lib/customizer}"
-    cw_CLUSTER_CUSTOMIZER_profiles="${cw_CLUSTER_CUSTOMIZER_profiles:-default}"
+    cw_CLUSTER_CUSTOMIZER_account_profiles="${cw_CLUSTER_CUSTOMIZER_account_profiles:-default}"
     customize_fetch
 else
     action_die 'unable to pull: no cloud metadata service detected'

--- a/clusterware-customize/libexec/customize/actions/pull
+++ b/clusterware-customize/libexec/customize/actions/pull
@@ -21,24 +21,18 @@
 # https://github.com/alces-software/clusterware
 #==============================================================================
 require action
+require customize
 require handler
 require network
 require process
 
 process_reexec_sudo "$@"
 
-if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
-    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
-    require customize
-
-    if network_has_metadata_service 1; then
-        files_load_config cluster-customizer
-        cw_CLUSTER_CUSTOMIZER_path="${cw_CLUSTER_CUSTOMIZER_path:-${cw_ROOT}/var/lib/customizer}"
-        cw_CLUSTER_CUSTOMIZER_profiles="${cw_CLUSTER_CUSTOMIZER_profiles:-default}"
-        customize_fetch
-    else
-        action_die 'unable to pull: no cloud metadata service detected'
-    fi
+if network_has_metadata_service 1; then
+    files_load_config cluster-customizer
+    cw_CLUSTER_CUSTOMIZER_path="${cw_CLUSTER_CUSTOMIZER_path:-${cw_ROOT}/var/lib/customizer}"
+    cw_CLUSTER_CUSTOMIZER_profiles="${cw_CLUSTER_CUSTOMIZER_profiles:-default}"
+    customize_fetch
 else
-    action_die 'cluster-customizer handler is not enabled'
+    action_die 'unable to pull: no cloud metadata service detected'
 fi

--- a/clusterware-customize/libexec/customize/actions/pull
+++ b/clusterware-customize/libexec/customize/actions/pull
@@ -1,0 +1,44 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2016 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+require action
+require handler
+require network
+require process
+
+process_reexec_sudo "$@"
+
+if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
+    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
+    require customize
+
+    if network_has_metadata_service 1; then
+        files_load_config cluster-customizer
+        cw_CLUSTER_CUSTOMIZER_path="${cw_CLUSTER_CUSTOMIZER_path:-${cw_ROOT}/var/lib/customizer}"
+        cw_CLUSTER_CUSTOMIZER_profiles="${cw_CLUSTER_CUSTOMIZER_profiles:-default}"
+        customize_fetch
+    else
+        action_die 'unable to pull: no cloud metadata service detected'
+    fi
+else
+    action_die 'cluster-customizer handler is not enabled'
+fi

--- a/clusterware-customize/libexec/customize/actions/push
+++ b/clusterware-customize/libexec/customize/actions/push
@@ -1,0 +1,36 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2016 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+require action
+require customize-repository
+require handler
+require network
+require process
+
+process_reexec_sudo "$@"
+
+if network_has_metadata_service 1; then
+    files_load_config cluster-customizer
+    customize_repository_push "$@"
+else
+    action_die 'unable to pull: no cloud metadata service detected'
+fi

--- a/clusterware-customize/libexec/customize/actions/push
+++ b/clusterware-customize/libexec/customize/actions/push
@@ -22,7 +22,7 @@
 #==============================================================================
 require action
 require customize-repository
-require handler
+require files
 require network
 require process
 

--- a/clusterware-customize/libexec/customize/actions/trigger
+++ b/clusterware-customize/libexec/customize/actions/trigger
@@ -1,0 +1,85 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2016 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+require action
+require process
+require handler
+require member
+
+_run_member_hooks() {
+    local event name ip
+    members="$1"
+    event="$2"
+    shift 3
+    name="$1"
+    ip="$2"
+    if [[ -z "${members}" || ,"$members", == *,"${name}",* ]]; then
+       customize_run_hooks "${event}" \
+                           "${cw_MEMBER_DIR}"/"${name}" \
+                           "${name}" \
+                           "${ip}"
+    fi
+}
+
+main() {
+    local event event_spec members
+    if [ "$1" == "-m" ]; then
+        members="$2"
+        shift 2
+    fi
+    event="$1"
+    if [ -z "$event" ]; then
+        action_die "usage: ${cw_BINNAME} [-m <members>] <event> [<feature>]"
+    fi
+    if [ "$2" ]; then
+        event_spec="${event}:$2"
+    else
+        event_spec="${event}"
+    fi
+
+    case $event in
+        initialize|configure|start|fail|node-started|event-periodic)
+            customize_run_hooks "$event_spec"
+            ;;
+        member-join)
+            # XXX - select one or more members?
+            member_each _run_member_hooks "${members}" "${event_spec}"
+            ;;
+        member-leave)
+            action_die "manual trigger of member-leave hooks is not currently supported"
+            ;;
+        *)
+            action_die "unable to trigger unrecognized event: $event"
+            ;;
+    esac
+}
+
+if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
+    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
+    require customize
+
+    process_reexec_sudo "$@"
+
+    main "$@"
+else
+    action_die 'cluster-customizer handler is not enabled'
+fi

--- a/clusterware-customize/libexec/customize/actions/trigger
+++ b/clusterware-customize/libexec/customize/actions/trigger
@@ -21,6 +21,7 @@
 # https://github.com/alces-software/clusterware
 #==============================================================================
 require action
+require customize
 require process
 require handler
 require member
@@ -73,13 +74,8 @@ main() {
     esac
 }
 
-if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
-    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
-    require customize
+require customize
 
-    process_reexec_sudo "$@"
+process_reexec_sudo "$@"
 
-    main "$@"
-else
-    action_die 'cluster-customizer handler is not enabled'
-fi
+main "$@"

--- a/clusterware-customize/metadata.yml
+++ b/clusterware-customize/metadata.yml
@@ -1,0 +1,30 @@
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+---
+install:
+  _: |
+    require serviceware
+    serviceware_add clusterware-customize
+
+    cp -pR libexec/* "${cw_ROOT}"/libexec
+
+    cp -pR lib/* "${cw_ROOT}"/lib


### PR DESCRIPTION
This PR moves the `alces customize` actions into a new `clusterware-customize` service, as well as a number of other enhancements.

### Profile repositories
The biggest change is the new concept of a customization profile _repository_ - essentially, a collection of customization profiles (as with the existing S3 buckets) with an index YAML file. The customizer can be configured to search multiple repositories, hosted either over S3, HTTP or on a filesystem, for installable profiles.

There's a script in the `flight-profiles` Github repo to generate an `index.yml` file as part of the process of uploading that repository to S3. Additionally, the `alces customize makeindex <repository_root>` command is available to do likewise from within a Clusterware environment.

### Profile tags
We now support the option of adding text "tags" to a profile: short pieces of text describing attributes of the profile. Alces-curated profiles will either be tagged `software` or `config`, depending on what the profile contains. Profiles designed to be applied at boot-time (e.g. have `initialize` or `preconfigure` scripts) are tagged as `startup` and cannot be applied at runtime. Profiles tagged `hidden` are not displayed by `alces customize list`, but can still be applied.

Tags are applied via a text file `tags.txt` in the root of the profile directory, alongside `manifest.txt`, and are automatically collected into `index.yml` by the relevant scripts/commands.

### `alces customize push`
A new `push` command has been added to make it straightforward to add new profiles to a repository. It has two modes of operation:

#### Single-script push
Wraps a single script into a customization profile, and pushes it to a repo.

`alces customize push myscript.sh [myrepo] [hook_name]`

Takes `myscript.sh`, puts it in a `hook_name.d` profile subdirectory (default: `configure`), generates a manifest, and pushes it to `myrepo` (default: `account`), updating or creating `myrepo`'s index at the same time.

#### Directory push
Takes an entire directory as a profile, and pushes it to a repo.

`alces customize push myprofiledir [myrepo]`

Takes `myprofiledir` and, assuming it contains one or more subdirectories, generates a manifest and pushes it to `myrepo` (default: `account`), updating or creating `myrepo`'s index at the same time.

#### Other changes
This PR also includes changes from @mjtko (fix to `fetch` when the first S3 bucket tried is unreachable) and @benarmston (changes to `job-queue` commands).

#### Related PRs
- `clusterware-handlers`: https://github.com/alces-software/clusterware-handlers/pull/70
- `flight-profiles`: TBC