### PR TITLE
Prevent gridware command error if no args given

### DIFF
--- a/gridware/libexec/actions/gridware
+++ b/gridware/libexec/actions/gridware
@@ -27,6 +27,11 @@ DOC
 # https://github.com/alces-software/clusterware
 #==============================================================================
 # vim: set filetype=ruby :
+#ALCES_META
+# Refer to `clusterware/scripts/development/propagate`.
+#path=/opt/clusterware/libexec/actions/gridware
+#ALCES_META_END
+
 # Execute as ruby script if we're evaluating under bash
 if [ "" ]; then 0; else eval 'cw_RUBY_EXEC "$@" || exit 1'; fi; end
 

--- a/gridware/libexec/actions/gridware
+++ b/gridware/libexec/actions/gridware
@@ -48,10 +48,10 @@ end
 
 File.umask(0002)
 
-if (ARGV[0].length >= 3 && 'init'.start_with?(ARGV[0]))
+if (!ARGV.empty? && ARGV[0].length >= 3 && 'init'.start_with?(ARGV[0]))
   ARGV.shift
   Kernel.exec "#{ENV['cw_ROOT']}/libexec/gridware/actions/init", *ARGV
-elsif (ARGV[0].length >= 2 && 'docker'.start_with?(ARGV[0]))
+elsif (!ARGV.empty? && ARGV[0].length >= 2 && 'docker'.start_with?(ARGV[0]))
   ARGV.shift
   Kernel.exec "#{ENV['cw_ROOT']}/libexec/gridware/actions/docker", *ARGV
 else


### PR DESCRIPTION
Previously, when run without arguments the `alces gridware` command would give the following error due to the `ARGV` array being empty:

```
[alces@login1(bobcluster) ~]$ alces gridware
/opt/clusterware/libexec/actions/gridware:46:in `<main>': undefined method `length' for nil:NilClass (NoMethodError)
```

Checking that `ARGV` is not empty before accessing it prevents this, and makes Gridware itself handle the error by stating this is an `invalid command`.
