### PR TITLE
Install missing s3cmd dependency

### DIFF
--- a/clusterware-customize/lib/functions/customize-repository-s3.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository-s3.functions.sh
@@ -131,9 +131,6 @@ customize_repository_s3_push() {
   fi
 
   $S3CMD sync --delete-removed \
-              --default-mime-type=text/plain \
-              --guess-mime-type \
-              --no-mime-magic \
               "$src" "$dest"
   retval=$?
 
@@ -148,7 +145,7 @@ customize_repository_s3_set_index() {
 
   _customize_repository_s3_set_s3_config
 
-  $S3CMD put --no-mime-magic --default-mime-type=text/plain "$index" "${repo_url}/index.yml"
+  $S3CMD put "$index" "${repo_url}/index.yml"
   retval=$?
 
   _customize_repository_s3_clear_s3_config

--- a/clusterware-customize/lib/functions/job-queue.functions.sh
+++ b/clusterware-customize/lib/functions/job-queue.functions.sh
@@ -98,21 +98,8 @@ job_queue_save_job_output() {
     job_id=$2
     output_dir=$3
 
-    # python-magic isn't installed on our clusters by default and without it
-    # the results files are uploaded as binary/octet-stream, which breaks
-    # viewing the logs in a browser tab.
-    #
-    # Most of the files should be text/plain, so we use that as the default
-    # and try to get s3cmd to use the file extension for guessing others.
-    #
-    # Using `--no-mime-magic` prevents the logs from filling with warnings
-    # about python-magic not being available.
-
     "${cw_ROOT}"/opt/s3cmd/s3cmd put --recursive \
         --acl-public \
-        --default-mime-type=text/plain \
-        --guess-mime-type \
-        --no-mime-magic \
         $(job_queue_work_dir_path "${queue}" "${output_dir}"/"${job_id}"/"$(hostname)") \
         $(job_queue_bucket_path "${queue}" "${output_dir}"/"${job_id}")/
 

--- a/clusterware-sync/libexec/sync/actions/push
+++ b/clusterware-sync/libexec/sync/actions/push
@@ -171,16 +171,16 @@ _push() {
         mkdir -p "$(xdg_cache_home)"/clusterware
         if _prepare_encrypt_set "${sync_cfg}" "${encrypted_file}"; then
             doing "Sync"
-            ${_S3CMD} --no-progress --no-mime-magic put \
+            ${_S3CMD} --no-progress put \
                       "${encrypted_file}" \
                       s3://${bucket}/sync/$(whoami)/${target}.dat >> "$(xdg_cache_home)"/clusterware/flight-sync.log 2>&1
         else
             doing "Sync"
         fi
-        ${_S3CMD} --no-progress --no-mime-magic put \
+        ${_S3CMD} --no-progress put \
                   "${sync_cfg}" \
                   s3://${bucket}/sync/$(whoami)/${target}.yml >> "$(xdg_cache_home)"/clusterware/flight-sync.log 2>&1
-        ${_S3CMD} --no-progress --no-mime-magic sync \
+        ${_S3CMD} --no-progress sync \
                   --delete-removed \
                   --exclude-from ${exclusions_file} \
                   "$(_target_for "${sync_cfg}")"/ \

--- a/s3cmd/metadata.yml
+++ b/s3cmd/metadata.yml
@@ -22,11 +22,11 @@
 ---
 install:
   el7: |
-    yum -e0 -y install python-dateutil
+    yum -e0 -y install python-dateutil python-magic
   el6: |
-    yum -e0 -y install python-dateutil
+    yum -e0 -y install python-dateutil python-magic
   ubuntu1604: |
-    apt-get install -y python-dateutil
+    apt-get install -y python-dateutil python-magic
   _: |
     require serviceware
     serviceware_add s3cmd


### PR DESCRIPTION
Rather than attempting to work around lack of this.

Previously if s3cmd was run without passing the `--no-mime-magic` option, and a file upload was attempted, then the following warning would be given:

```
WARNING: Module python-magic is not available. Guessing MIME types based on file extensions.
```

We attempt to work around this in some places but rather than do this, and do this inconsistently, this commit just installs the dependency; this gets rid of the warning and should mean MIME types are detected
correctly.