### PR TITLE
Running job queue jobs on any node

### DIFF
--- a/clusterware-customize/README-job-queue.md
+++ b/clusterware-customize/README-job-queue.md
@@ -16,23 +16,24 @@ the account (e.g. `alces-flight-nmi0ztdmyzm3ztm3`), and `$customizer_name`
 refers to any customizer profile name (e.g.  `prime-continuous-delivery` or
 `domain-dev.alces.network`).
 
-For each such customizer profile, a particular cluster with name
-`$cluster_name` will process any scripts in
-`$customizer_profile/job-queue.d/${cluster_name}/pending`. One way to add
-scripts to a queue for a cluster is to manually upload them to the appropriate
+For each such customizer profile, a particular cluster node with name `$node`,
+in Cluster `$cluster` and Domain `$domain`, will process any scripts in
+`$customizer_profile/job-queue.d/$node.$cluster.$domain/pending`. One way to
+add scripts to a queue for a node is to manually upload them to the appropriate
 folder; another way is to use the `alces customize job-queue put
 $customizer_name $script`, which will upload the given `$script` to the
-`$customizer_name` customizer profile queue for that cluster.
+`$customizer_name` customizer profile queue for the login node of the current
+cluster.
 
-Note that currently jobs will only be run on the master node for a cluster.
-However, multiple clusters with the same name in different domains for an
-account will currently all pick up and process the same job, unless one cluster
-completes processing it before another picks it up.
+Note that currently the `alces customize job-queue` commands will only interact
+with the job queue for the current cluster's login node, however the job queues
+for other nodes can be interacted with by uploading and reading files from S3
+directly.
 
 The results of running the job are stored on s3 with the following prefix:
-`$customizer_profile/job-queue.d/${cluster_name}`. Specifically, output will
-be available at `${prefix}/completed/${job_id}/logs` and its exit code will be
-available at `${prefix}/completed/${job_id}/status.`
+`$customizer_profile/job-queue.d/$node.$cluster.$domain`. Specifically, output
+will be available at `${prefix}/completed/${job_id}/logs` and its exit code
+will be available at `${prefix}/completed/${job_id}/status.`
 
 ## Custom job runners
 

--- a/clusterware-customize/lib/functions/job-queue.functions.sh
+++ b/clusterware-customize/lib/functions/job-queue.functions.sh
@@ -19,6 +19,10 @@
 # For more information on the Alces Clusterware, please visit:
 # https://github.com/alces-software/clusterware
 #==============================================================================
+#ALCES_META
+# Refer to `clusterware/scripts/development/propagate`.
+#path=/opt/clusterware/lib/functions/job-queue.functions.sh
+#ALCES_META_END
 require files
 require network
 

--- a/clusterware-customize/lib/functions/job-queue.functions.sh
+++ b/clusterware-customize/lib/functions/job-queue.functions.sh
@@ -26,17 +26,40 @@
 require files
 require network
 
-job_queue_bucket_path() {
-    local queue relative_path fqdn node cluster domain_name job_queue_folder bucket_folder
+job_queue_bucket_put_path() {
+    local queue relative_path node
     queue="$1"
     relative_path="$2"
 
+    # When putting/viewing jobs using `alces customize job-queue` commands, we
+    # currently always only want to interact with the queue folder for the
+    # cluster login node.
+    node="login1"
+
+    _job_queue_bucket_path "$node" "$queue" "$relative_path"
+}
+
+job_queue_bucket_pull_path() {
+    local queue relative_path current_node
+    queue="$1"
+    relative_path="$2"
+
+    # When pulling down jobs to be run, we only want to get jobs intended for
+    # the current node.
+    current_node="$(hostname --fqdn | cut -d. -f1)"
+
+    _job_queue_bucket_path "$current_node" "$queue" "$relative_path"
+}
+
+_job_queue_bucket_path() {
+    local node queue relative_path fqdn cluster domain_name job_queue_folder bucket_folder
+    node="$1"
+    queue="$2"
+    relative_path="$3"
+
     fqdn="$(hostname --fqdn)"
 
-    # Currently the `alces customize job-queue` tool only supports adding jobs
-    # to be run on the login node of the current cluster. Note: `domain` will
-    # be `prv` for Flight Solo clusters.
-    node='login1'
+    # Note: `domain` will be `prv` for Flight Solo clusters.
     cluster=$(echo "$fqdn" | cut -d. -f2)
     domain=$(echo "$fqdn" | cut -d. -f3)
     job_queue_folder="${node}.${cluster}.${domain}"
@@ -101,7 +124,7 @@ job_queue_get_job_handling_customizations() {
 job_queue_get_pending_jobs() {
     local queue s3_pending_dir local_pending_dir
     queue="$1"
-    s3_pending_dir="$(job_queue_bucket_path "${queue}" pending/)"
+    s3_pending_dir="$(job_queue_bucket_pull_path "${queue}" pending/)"
     local_pending_dir="$(job_queue_work_dir_path "${queue}" pending/)"
 
     mkdir -p "${local_pending_dir}"
@@ -117,7 +140,7 @@ job_queue_save_job_output() {
     "${cw_ROOT}"/opt/s3cmd/s3cmd put --recursive \
         --acl-public \
         $(job_queue_work_dir_path "${queue}" "${output_dir}"/"${job_id}"/"$(hostname)") \
-        $(job_queue_bucket_path "${queue}" "${output_dir}"/"${job_id}")/
+        $(job_queue_bucket_pull_path "${queue}" "${output_dir}"/"${job_id}")/
 
     mkdir -p /var/log/clusterware/prime-continuous-delivery/
     rsync -a $(job_queue_work_dir_path "${queue}" "${output_dir}"/) \
@@ -134,7 +157,7 @@ job_queue_validate_job_id() {
     rejected_file=$3
 
     existing=$( "${cw_ROOT}"/opt/s3cmd/s3cmd ls \
-        $(job_queue_bucket_path "${queue}" completed/"${job_id}"/"$(hostname)") \
+        $(job_queue_bucket_pull_path "${queue}" completed/"${job_id}"/"$(hostname)") \
         | wc -l
     )
 
@@ -284,7 +307,7 @@ job_queue_list_jobs_in_queue() {
     job_status="$2"
 
     job_queue_s3cmd_setup
-    s3_prefix=$(job_queue_bucket_path "${queue}" "${job_status}"/ )
+    s3_prefix=$(job_queue_bucket_put_path "${queue}" "${job_status}"/ )
 
     "${cw_ROOT}"/opt/s3cmd/s3cmd ls ${s3_prefix} \
         | rev \
@@ -299,7 +322,7 @@ job_queue_put() {
     job_id="$3"
 
     job_queue_s3cmd_setup
-    s3_key=$(job_queue_bucket_path "${queue}" pending/"${job_id}" )
+    s3_key=$(job_queue_bucket_put_path "${queue}" pending/"${job_id}" )
 
     "${cw_ROOT}"/opt/s3cmd/s3cmd put --quiet ${job_file} ${s3_key}
 }
@@ -311,7 +334,7 @@ job_queue_list_output_files() {
 
     job_queue_s3cmd_setup
     job_status=$(job_queue_get_job_status "${queue}" "${job_id}")
-    s3_key=$(job_queue_bucket_path "${queue}" "${job_status}"/"${job_id}"/ )
+    s3_key=$(job_queue_bucket_put_path "${queue}" "${job_status}"/"${job_id}"/ )
 
     "${cw_ROOT}"/opt/s3cmd/s3cmd ls --recursive ${s3_key} \
         | awk '{print $4}' \
@@ -327,7 +350,7 @@ job_queue_get_output_file() {
 
     job_queue_s3cmd_setup
     job_status=$(job_queue_get_job_status "${queue}" "${job_id}")
-    s3_key=$(job_queue_bucket_path "${queue}" "${job_status}"/"${job_id}"/"${output_file}" )
+    s3_key=$(job_queue_bucket_put_path "${queue}" "${job_status}"/"${job_id}"/"${output_file}" )
 
     "${cw_ROOT}"/opt/s3cmd/s3cmd get ${s3cmd_args[@]} ${s3_key} -
 }
@@ -339,19 +362,19 @@ job_queue_get_job_status() {
 
     job_queue_s3cmd_setup
 
-    s3_key=$(job_queue_bucket_path "${queue}" pending/"${job_id}" )
+    s3_key=$(job_queue_bucket_put_path "${queue}" pending/"${job_id}" )
     if [ $( "${cw_ROOT}"/opt/s3cmd/s3cmd ls ${s3_key} | wc -l ) -ne 0 ] ; then
         echo "pending"
         return 0
     fi
 
-    s3_key=$(job_queue_bucket_path "${queue}" completed/"${job_id}" )
+    s3_key=$(job_queue_bucket_put_path "${queue}" completed/"${job_id}" )
     if [ $( "${cw_ROOT}"/opt/s3cmd/s3cmd ls ${s3_key} | wc -l ) -ne 0 ] ; then
         echo "completed"
         return 0
     fi
 
-    s3_key=$(job_queue_bucket_path "${queue}" rejected/"${job_id}" )
+    s3_key=$(job_queue_bucket_put_path "${queue}" rejected/"${job_id}" )
     if [ $( "${cw_ROOT}"/opt/s3cmd/s3cmd ls ${s3_key} | wc -l ) -ne 0 ] ; then
         echo "rejected"
         return 0
@@ -364,6 +387,6 @@ job_queue_delete_job() {
     job_id="$2"
 
     job_queue_s3cmd_setup
-    s3_key=$(job_queue_bucket_path "${queue}" pending/"${job_id}" )
+    s3_key=$(job_queue_bucket_put_path "${queue}" pending/"${job_id}" )
     "${cw_ROOT}"/opt/s3cmd/s3cmd rm --quiet ${s3_key}
 }

--- a/clusterware-customize/lib/functions/job-queue.functions.sh
+++ b/clusterware-customize/lib/functions/job-queue.functions.sh
@@ -61,7 +61,7 @@ job_queue_get_job_queues() {
         | cut -d/ -f5 \
         | uniq
     )
-    for customizer in ${queue_customizers} ; do 
+    for customizer in ${queue_customizers} ; do
         job_queues+=("${customizer}")
     done
 }
@@ -167,7 +167,7 @@ job_queue_execute_job() {
     files_load_config instance config/cluster
 
     if [ -f "${custom_job_runner}" ] ; then
-        # If there is a custom job runner, use it to run the job file. 
+        # If there is a custom job runner, use it to run the job file.
         chmod +x "${custom_job_runner}"
         "${custom_job_runner}" \
             "${job_file}" \

--- a/clusterware-customize/lib/functions/job-queue.functions.sh
+++ b/clusterware-customize/lib/functions/job-queue.functions.sh
@@ -27,14 +27,16 @@ require files
 require network
 
 job_queue_bucket_path() {
-    local queue relative_path
+    local queue relative_path bucket_folder
     queue="$1"
     relative_path="$2"
 
+    bucket_folder="${BUCKET}/customizer/${queue}/job-queue.d/${cw_CLUSTER_name}"
+
     if [ "${relative_path}" == "" ] ; then
-        echo "${BUCKET}/customizer/${queue}/job-queue.d/${cw_CLUSTER_name}"
+        echo "${bucket_folder}"
     else
-        echo "${BUCKET}/customizer/${queue}/job-queue.d/${cw_CLUSTER_name}/${relative_path}"
+        echo "${bucket_folder}/${relative_path}"
     fi
 }
 

--- a/clusterware-customize/lib/functions/job-queue.functions.sh
+++ b/clusterware-customize/lib/functions/job-queue.functions.sh
@@ -26,7 +26,7 @@
 require files
 require network
 
-job_queue_bucket_put_path() {
+job_queue_bucket_master_path() {
     local queue relative_path node
     queue="$1"
     relative_path="$2"
@@ -39,7 +39,7 @@ job_queue_bucket_put_path() {
     _job_queue_bucket_path "$node" "$queue" "$relative_path"
 }
 
-job_queue_bucket_pull_path() {
+job_queue_bucket_node_path() {
     local queue relative_path current_node
     queue="$1"
     relative_path="$2"
@@ -124,7 +124,7 @@ job_queue_get_job_handling_customizations() {
 job_queue_get_pending_jobs() {
     local queue s3_pending_dir local_pending_dir
     queue="$1"
-    s3_pending_dir="$(job_queue_bucket_pull_path "${queue}" pending/)"
+    s3_pending_dir="$(job_queue_bucket_node_path "${queue}" pending/)"
     local_pending_dir="$(job_queue_work_dir_path "${queue}" pending/)"
 
     mkdir -p "${local_pending_dir}"
@@ -140,7 +140,7 @@ job_queue_save_job_output() {
     "${cw_ROOT}"/opt/s3cmd/s3cmd put --recursive \
         --acl-public \
         $(job_queue_work_dir_path "${queue}" "${output_dir}"/"${job_id}"/"$(hostname)") \
-        $(job_queue_bucket_pull_path "${queue}" "${output_dir}"/"${job_id}")/
+        $(job_queue_bucket_node_path "${queue}" "${output_dir}"/"${job_id}")/
 
     mkdir -p /var/log/clusterware/prime-continuous-delivery/
     rsync -a $(job_queue_work_dir_path "${queue}" "${output_dir}"/) \
@@ -157,7 +157,7 @@ job_queue_validate_job_id() {
     rejected_file=$3
 
     existing=$( "${cw_ROOT}"/opt/s3cmd/s3cmd ls \
-        $(job_queue_bucket_pull_path "${queue}" completed/"${job_id}"/"$(hostname)") \
+        $(job_queue_bucket_node_path "${queue}" completed/"${job_id}"/"$(hostname)") \
         | wc -l
     )
 
@@ -307,7 +307,7 @@ job_queue_list_jobs_in_queue() {
     job_status="$2"
 
     job_queue_s3cmd_setup
-    s3_prefix=$(job_queue_bucket_put_path "${queue}" "${job_status}"/ )
+    s3_prefix=$(job_queue_bucket_master_path "${queue}" "${job_status}"/ )
 
     "${cw_ROOT}"/opt/s3cmd/s3cmd ls ${s3_prefix} \
         | rev \
@@ -322,7 +322,7 @@ job_queue_put() {
     job_id="$3"
 
     job_queue_s3cmd_setup
-    s3_key=$(job_queue_bucket_put_path "${queue}" pending/"${job_id}" )
+    s3_key=$(job_queue_bucket_master_path "${queue}" pending/"${job_id}" )
 
     "${cw_ROOT}"/opt/s3cmd/s3cmd put --quiet ${job_file} ${s3_key}
 }
@@ -334,7 +334,7 @@ job_queue_list_output_files() {
 
     job_queue_s3cmd_setup
     job_status=$(job_queue_get_job_status "${queue}" "${job_id}")
-    s3_key=$(job_queue_bucket_put_path "${queue}" "${job_status}"/"${job_id}"/ )
+    s3_key=$(job_queue_bucket_master_path "${queue}" "${job_status}"/"${job_id}"/ )
 
     "${cw_ROOT}"/opt/s3cmd/s3cmd ls --recursive ${s3_key} \
         | awk '{print $4}' \
@@ -350,7 +350,7 @@ job_queue_get_output_file() {
 
     job_queue_s3cmd_setup
     job_status=$(job_queue_get_job_status "${queue}" "${job_id}")
-    s3_key=$(job_queue_bucket_put_path "${queue}" "${job_status}"/"${job_id}"/"${output_file}" )
+    s3_key=$(job_queue_bucket_master_path "${queue}" "${job_status}"/"${job_id}"/"${output_file}" )
 
     "${cw_ROOT}"/opt/s3cmd/s3cmd get ${s3cmd_args[@]} ${s3_key} -
 }
@@ -362,19 +362,19 @@ job_queue_get_job_status() {
 
     job_queue_s3cmd_setup
 
-    s3_key=$(job_queue_bucket_put_path "${queue}" pending/"${job_id}" )
+    s3_key=$(job_queue_bucket_master_path "${queue}" pending/"${job_id}" )
     if [ $( "${cw_ROOT}"/opt/s3cmd/s3cmd ls ${s3_key} | wc -l ) -ne 0 ] ; then
         echo "pending"
         return 0
     fi
 
-    s3_key=$(job_queue_bucket_put_path "${queue}" completed/"${job_id}" )
+    s3_key=$(job_queue_bucket_master_path "${queue}" completed/"${job_id}" )
     if [ $( "${cw_ROOT}"/opt/s3cmd/s3cmd ls ${s3_key} | wc -l ) -ne 0 ] ; then
         echo "completed"
         return 0
     fi
 
-    s3_key=$(job_queue_bucket_put_path "${queue}" rejected/"${job_id}" )
+    s3_key=$(job_queue_bucket_master_path "${queue}" rejected/"${job_id}" )
     if [ $( "${cw_ROOT}"/opt/s3cmd/s3cmd ls ${s3_key} | wc -l ) -ne 0 ] ; then
         echo "rejected"
         return 0
@@ -387,6 +387,6 @@ job_queue_delete_job() {
     job_id="$2"
 
     job_queue_s3cmd_setup
-    s3_key=$(job_queue_bucket_put_path "${queue}" pending/"${job_id}" )
+    s3_key=$(job_queue_bucket_master_path "${queue}" pending/"${job_id}" )
     "${cw_ROOT}"/opt/s3cmd/s3cmd rm --quiet ${s3_key}
 }

--- a/clusterware-customize/lib/functions/job-queue.functions.sh
+++ b/clusterware-customize/lib/functions/job-queue.functions.sh
@@ -32,9 +32,9 @@ job_queue_bucket_path() {
     relative_path="$2"
 
     if [ "${relative_path}" == "" ] ; then
-        echo "${BUCKET}"/customizer/"${queue}"/job-queue.d/"${cw_CLUSTER_name}"
+        echo "${BUCKET}/customizer/${queue}/job-queue.d/${cw_CLUSTER_name}"
     else
-        echo "${BUCKET}"/customizer/"${queue}"/job-queue.d/"${cw_CLUSTER_name}"/"${relative_path}"
+        echo "${BUCKET}/customizer/${queue}/job-queue.d/${cw_CLUSTER_name}/${relative_path}"
     fi
 }
 

--- a/clusterware-customize/lib/functions/job-queue.functions.sh
+++ b/clusterware-customize/lib/functions/job-queue.functions.sh
@@ -27,11 +27,21 @@ require files
 require network
 
 job_queue_bucket_path() {
-    local queue relative_path bucket_folder
+    local queue relative_path fqdn node cluster domain_name job_queue_folder bucket_folder
     queue="$1"
     relative_path="$2"
 
-    bucket_folder="${BUCKET}/customizer/${queue}/job-queue.d/${cw_CLUSTER_name}"
+    fqdn="$(hostname --fqdn)"
+
+    # Currently the `alces customize job-queue` tool only supports adding jobs
+    # to be run on the login node of the current cluster. Note: `domain` will
+    # be `prv` for Flight Solo clusters.
+    node='login1'
+    cluster=$(echo "$fqdn" | cut -d. -f2)
+    domain=$(echo "$fqdn" | cut -d. -f3)
+    job_queue_folder="${node}.${cluster}.${domain}"
+
+    bucket_folder="${BUCKET}/customizer/${queue}/job-queue.d/${job_queue_folder}"
 
     if [ "${relative_path}" == "" ] ; then
         echo "${bucket_folder}"


### PR DESCRIPTION
This PR allows running customizer job queue jobs on any cluster node, rather than just on the login node as was the previous behaviour; this is a change required by https://github.com/alces-software/imageware/issues/94. This PR also fixes https://github.com/alces-software/clusterware-services/issues/36; fixing this issue and adding this feature both required changes to the same code so it made sense to group them together.

The important changes are in https://github.com/alces-software/clusterware-services/commit/b64ba95cbe561600247467ce3263a6c90b5f1112 and https://github.com/alces-software/clusterware-services/commit/5e15b82c57be5618f8ad84d019c5bc45850b6a9b; the other commits are minor supporting changes.

It would probably be useful if @benarmston could take a quick look at this as you worked on the original feature, as well as @mjtko since you know the most about Clusterware. Thanks.