### PR TITLE
Fixed reterival process and trigger 

### DIFF
--- a/clusterware-customize/lib/functions/customize-repository.functions.sh
+++ b/clusterware-customize/lib/functions/customize-repository.functions.sh
@@ -241,9 +241,11 @@ customize_repository_apply() {
         return 1
       fi
       chmod -R a+x "${cw_CLUSTER_CUSTOMIZER_path}/${repo_name}-${profile_name}"
-      echo "Running configure for $profile_name"
-      customize_run_hooks "configure:$repo_name-$profile_name"
-      member_each _run_member_hooks "${members}" "member-join:$repo_name-$profile_name"
+      if [[ "$is_preinit" != "preinit" ]]; then
+        echo "Running configure for $profile_name"
+        customize_run_hooks "configure:$repo_name-$profile_name"
+        member_each _run_member_hooks "${members}" "member-join:$repo_name-$profile_name"
+      fi
       return 0
     fi
   else

--- a/clusterware-customize/lib/functions/customize.functions.sh
+++ b/clusterware-customize/lib/functions/customize.functions.sh
@@ -46,12 +46,10 @@ customize_list_hooks() {
 }
 
 customize_run_hooks() {
-    local a p hook paths feature feature_ran_bool
+    local a p hook paths profile profile_found
     hook="$1"
-    feature_ran_bool=0
     if [[ "$hook" == *":"* ]]; then
-        feature_ran_bool=-1
-        feature=$(echo "${hook#*:}" | sed -e 's/\//-/g')
+        profile=$(echo "${hook#*:}" | sed -e 's/\//-/g')
         hook="${hook%:*}"
     fi
     shift
@@ -64,8 +62,8 @@ customize_run_hooks() {
         paths="${paths} ${p}"
     done
     for p in ${paths}; do
-        if [[ -z "${feature}" || "${p}" == */"${feature}" ]]; then
-            feature_ran_bool=0
+        if [[ -z "${profile}" || "${p}" == */"${profile}" ]]; then
+            profile_found=true
             if [ -d "${p}"/${hook}.d ]; then
                 for a in "${p}"/${hook}.d/*; do
                     if [ -x "$a" -a ! -d "$a" ] && [[ "$a" != *~ ]]; then
@@ -83,9 +81,8 @@ customize_run_hooks() {
             fi
         fi
     done
-    if [[ feature_ran_bool -ne 0 ]]; then
-        echo "No profile $feature found"
-        exit -1
+    if [ -z "${profile_found}" ]; then
+        return 1
     fi
 }
 

--- a/clusterware-customize/lib/functions/customize.functions.sh
+++ b/clusterware-customize/lib/functions/customize.functions.sh
@@ -46,10 +46,12 @@ customize_list_hooks() {
 }
 
 customize_run_hooks() {
-    local a p hook paths feature
+    local a p hook paths feature feature_ran_bool
     hook="$1"
+    feature_ran_bool=0
     if [[ "$hook" == *":"* ]]; then
-        feature="${hook#*:}"
+        feature_ran_bool=-1
+        feature=$(echo "${hook#*:}" | sed -e 's/\//-/g')
         hook="${hook%:*}"
     fi
     shift
@@ -63,6 +65,7 @@ customize_run_hooks() {
     done
     for p in ${paths}; do
         if [[ -z "${feature}" || "${p}" == */"${feature}" ]]; then
+            feature_ran_bool=0
             if [ -d "${p}"/${hook}.d ]; then
                 for a in "${p}"/${hook}.d/*; do
                     if [ -x "$a" -a ! -d "$a" ] && [[ "$a" != *~ ]]; then
@@ -80,6 +83,10 @@ customize_run_hooks() {
             fi
         fi
     done
+    if [[ feature_ran_bool -ne 0 ]]; then
+        echo "No profile $feature found"
+        exit -1
+    fi
 }
 
 customize_set_region() {

--- a/clusterware-customize/libexec/customize/actions/trigger
+++ b/clusterware-customize/libexec/customize/actions/trigger
@@ -42,24 +42,27 @@ _run_member_hooks() {
 }
 
 main() {
-    local event event_spec members
+    local event event_spec profile members
     if [ "$1" == "-m" ]; then
         members="$2"
         shift 2
     fi
     event="$1"
+    profile="$2"
     if [ -z "$event" ]; then
-        action_die "usage: ${cw_BINNAME} [-m <members>] <event> [<feature>]"
+        action_die "usage: ${cw_BINNAME} [-m <members>] <event> [<profile>]"
     fi
-    if [ "$2" ]; then
-        event_spec="${event}:$2"
+    if [ "$profile" ]; then
+        event_spec="${event}:${profile}"
     else
         event_spec="${event}"
     fi
 
     case $event in
         initialize|configure|start|fail|node-started|event-periodic)
-            customize_run_hooks "$event_spec"
+            if ! customize_run_hooks "$event_spec"; then
+                action_die "profile not found: $profile"
+            fi
             ;;
         member-join)
             # XXX - select one or more members?


### PR DESCRIPTION
Slave nodes no longer run `member-join` and `configure` events when retrieving profiles.

The `profile` input for `alces customize trigger` is now delimited by both `/` and `-`. An error message is also included if the profile wasn't found to prevent `trigger` from failing silently