### PR TITLE
Gridware docker enhancements

### DIFF
--- a/gridware/docker/gridware-base/Dockerfile
+++ b/gridware/docker/gridware-base/Dockerfile
@@ -1,6 +1,6 @@
 FROM alces/clusterware-el7:1.7
-MAINTAINER Alces Software Ltd. <support@alces-software.com>
-LABEL Alces Gridware
+LABEL maintainer="Alces Software Ltd. <support@alces-software.com>" \
+      description="Alces Gridware - base image"
 
 RUN /opt/clusterware/bin/alces service install gridware && /opt/clusterware/bin/alces gridware init && yum clean all
 RUN mkdir -p /opt/gridware/bin

--- a/gridware/etc/profile.d/05-packager.sh
+++ b/gridware/etc/profile.d/05-packager.sh
@@ -152,7 +152,7 @@ fi;;
         "$(_cw_root)"/bin/alces gridware depot list -1 2>&1 | sed '
                 s#^\(.*\)/\(.\+\)(default)#\1\n\1\/\2#;
                 s#/*$##g; s#^base/##g;'
- 
+
     }
 
     _alces_list_cache_expired() {
@@ -164,10 +164,10 @@ fi;;
             return 1
         fi
     }
-    
+
     _alces_gridware() {
         local cur="$1" prev="$2" cmds opts
-        cmds="clean default help info install list purge update import export depot search requires"
+        cmds="clean default docker help info install list purge update import export depot search requires"
         if ((COMP_CWORD > 2)); then
             case "$prev" in
                 in*|r*)
@@ -191,6 +191,9 @@ fi;;
                     ;;
                 dep*)
                     COMPREPLY=( $(compgen -W "list enable disable update info install purge init" -- "$cur") )
+                    ;;
+                do*)
+                   COMPREPLY=( $(compgen -W "build help list pull push run share start-registry" -- "$cur") )
                     ;;
                 *)
                     # for purge, clean and default, we provide a module list

--- a/gridware/libexec/gridware/actions/docker
+++ b/gridware/libexec/gridware/actions/docker
@@ -42,7 +42,10 @@ case $action in
     b|bu|bui|buil|build)
         exec /bin/bash ${cw_ROOT}/libexec/gridware/actions/docker_build "$@"
         ;;
-    p|pu|pus|push)
+    pul|pull)
+        exec /bin/bash ${cw_ROOT}/libexec/gridware/actions/docker_pull "$@"
+        ;;
+    pus|push)
         exec /bin/bash ${cw_ROOT}/libexec/gridware/actions/docker_push "$@"
         ;;
     sh|sha|shar|share)

--- a/gridware/libexec/gridware/actions/docker
+++ b/gridware/libexec/gridware/actions/docker
@@ -45,8 +45,11 @@ case $action in
     p|pu|pus|push)
         exec /bin/bash ${cw_ROOT}/libexec/gridware/actions/docker_push "$@"
         ;;
-    s|sh|sha|shar|share)
+    sh|sha|shar|share)
         exec /bin/bash ${cw_ROOT}/libexec/gridware/actions/docker_share "$@"
+        ;;
+    st|sta|star|start|start-registry)
+        exec /bin/bash ${cw_ROOT}/libexec/gridware/actions/docker_start_registry "$@"
         ;;
     *)
         cat <<EOF

--- a/gridware/libexec/gridware/actions/docker
+++ b/gridware/libexec/gridware/actions/docker
@@ -65,7 +65,10 @@ printf "  %-27s  %s\n" "$cw_BINNAME help" "More help about this command."
 printf "  %-27s  %s\n" "$cw_BINNAME list" "List available Gridware containers."
 printf "  %-27s  %s\n" "$cw_BINNAME run" "Run a containerized Gridware application."
 printf "  %-27s  %s\n" "$cw_BINNAME build" "Build a containerized Gridware application."
-printf "  %-27s  %s\n" "$cw_BINNAME push" "Push a built container to the Docker registry."
+printf "  %-27s  %s\n" "$cw_BINNAME pull" "Push a container image from a Docker registry."
+printf "  %-27s  %s\n" "$cw_BINNAME push" "Push a built container image to the Docker registry."
+printf "  %-27s  %s\n" "$cw_BINNAME share" "Share a container image with other nodes in this cluster."
+printf "  %-27s  %s\n" "$cw_BINNAME start-registry" "Start a local Docker registry."
 cat <<EOF
 
 Please report bugs to support@alces-software.com

--- a/gridware/libexec/gridware/actions/docker
+++ b/gridware/libexec/gridware/actions/docker
@@ -45,6 +45,9 @@ case $action in
     p|pu|pus|push)
         exec /bin/bash ${cw_ROOT}/libexec/gridware/actions/docker_push "$@"
         ;;
+    s|sh|sha|shar|share)
+        exec /bin/bash ${cw_ROOT}/libexec/gridware/actions/docker_share "$@"
+        ;;
     *)
         cat <<EOF
 Usage: $cw_BINNAME COMMAND [[OPTION]... [ARGS]]

--- a/gridware/libexec/gridware/actions/docker_build
+++ b/gridware/libexec/gridware/actions/docker_build
@@ -43,8 +43,14 @@ _build_base() {
     docker build -t "$tag:latest" "${cw_ROOT}"/var/lib/gridware/docker/gridware-base
 }
 
+join_by () {
+  local IFS="$1"
+  shift
+  echo "$*"
+}
+
 main() {
-  local arg base_image default_script name package packages pkg_name provided_name variant
+  local arg base_image default_script display_name name package packages pkg_name provided_name variant
   packages=()
 
   # default base image and name
@@ -114,6 +120,7 @@ main() {
           package="$arg"
           name="${name}-$(echo "$arg" | tr '/' '-' | tr '[A-Z]' '[a-z]')"
         fi
+        display_name="${display_name}${arg}, "
         packages+=($package)
     esac
 
@@ -136,8 +143,9 @@ main() {
   build_dir="$(mktemp -d /tmp/gridware.docker.build.XXXXXXXX)"
   cat <<EOF > "${build_dir}"/Dockerfile
 FROM ${base_image}
-MAINTAINER Alces Software Ltd. <support@alces-software.com>
-LABEL Alces Gridware - $name
+LABEL maintainer="Alces Software Ltd. <support@alces-software.com>" \
+      description="Alces Gridware - ${display_name%%, }" \
+      alces.gridware.packages="$(join_by , "${packages[@]}")"
 EOF
 
   for package in "${packages[@]}"; do

--- a/gridware/libexec/gridware/actions/docker_build
+++ b/gridware/libexec/gridware/actions/docker_build
@@ -44,7 +44,7 @@ _build_base() {
 }
 
 main() {
-  local arg base_image default_script name package packages pkg_name variant
+  local arg base_image default_script name package packages pkg_name provided_name variant
   packages=()
 
   # default base image and name
@@ -64,6 +64,17 @@ main() {
       --from)
         if [ "$1" ]; then
           base_image="$_REGISTRY/$1"
+          shift
+        else
+          action_die "from parameter requires a value"
+        fi
+        ;;
+      --name)
+        if [ "$1" ]; then
+          provided_name=$(echo "$1" | tr '/' '-' )
+          if [[ "$provided_name" != "$1" ]]; then
+            echo "Using name ${provided_name} rather than specified ${1}"
+          fi
           shift
         else
           action_die "from parameter requires a value"
@@ -107,6 +118,10 @@ main() {
     esac
 
   done
+
+  if [ ! -z "$provided_name" ]; then
+    name="$provided_name"
+  fi
 
   tag="$_REGISTRY/$_REGISTRY_USER/$name"
 

--- a/gridware/libexec/gridware/actions/docker_build
+++ b/gridware/libexec/gridware/actions/docker_build
@@ -44,7 +44,7 @@ _build_base() {
 }
 
 main() {
-  local arg base_image name package packages pkg_name variant
+  local arg base_image default_script name package packages pkg_name variant
   packages=()
 
   # default base image and name
@@ -68,7 +68,15 @@ main() {
         else
           action_die "from parameter requires a value"
         fi
-          ;;
+        ;;
+      --script)
+        if [ ! -z "$1" ]; then
+          default_script="$1"
+          shift
+        else
+          action_die "script parameter requires a value"
+        fi
+        ;;
       --*)
         action_die "Unknown argument: $arg"
         ;;
@@ -131,6 +139,13 @@ yum clean all && \
 echo "$pkg_name" >> /opt/gridware/etc/defaults
 EOF
   done
+
+  if [ ! -z "$default_script" ]; then
+    # User has specified a default script to run
+    cp "${default_script}" "${build_dir}/default-cmd.sh"
+    chmod a+x "${build_dir}/default-cmd.sh"
+    echo "COPY default-cmd.sh /opt/gridware/bin/default-cmd.sh" >> "${build_dir}"/Dockerfile
+  fi
 
   set -o pipefail
   if ! docker build -t "$tag:latest" "$build_dir" 2>&1 | sed 's/^/  >>> /g'; then

--- a/gridware/libexec/gridware/actions/docker_build
+++ b/gridware/libexec/gridware/actions/docker_build
@@ -145,7 +145,8 @@ main() {
 FROM ${base_image}
 LABEL maintainer="Alces Software Ltd. <support@alces-software.com>" \
       description="Alces Gridware - ${display_name%%, }" \
-      alces.gridware.packages="$(join_by , "${packages[@]}")"
+      alces.gridware.packages="$(join_by , "${packages[@]}")" \
+      build-date="$(date "+%Y%m%d")"
 EOF
 
   for package in "${packages[@]}"; do

--- a/gridware/libexec/gridware/actions/docker_build
+++ b/gridware/libexec/gridware/actions/docker_build
@@ -101,7 +101,7 @@ main() {
           fi
         else
           package="$arg"
-          name="$name-$arg"
+          name="${name}-$(echo "$arg" | tr '/' '-' | tr '[A-Z]' '[a-z]')"
         fi
         packages+=($package)
     esac

--- a/gridware/libexec/gridware/actions/docker_build
+++ b/gridware/libexec/gridware/actions/docker_build
@@ -120,7 +120,12 @@ main() {
   done
 
   if [ ! -z "$provided_name" ]; then
-    name="$provided_name"
+    if [[ "$provided_name" != "gridware-"* ]]; then
+      # Image names must be prefixed with "gridware-" to be used with Gridware.
+      name="gridware-${provided_name}"
+    else
+      name="$provided_name"
+    fi
   fi
 
   tag="$_REGISTRY/$_REGISTRY_USER/$name"

--- a/gridware/libexec/gridware/actions/docker_build
+++ b/gridware/libexec/gridware/actions/docker_build
@@ -44,64 +44,102 @@ _build_base() {
 }
 
 main() {
-    local app name tag
-    if [ "$1" == "--base" ]; then
+  local arg base_image name package packages pkg_name variant
+  packages=()
+
+  # default base image and name
+  base_image="$_REGISTRY/$_REGISTRY_USER/gridware-base"
+  name="gridware"
+
+  while [ "$1" ]; do
+
+    arg="$1"
+    shift
+
+    case $arg in
+      --base)
         _build_base
-    else
-        if [ "$1" == "--from" ]; then
-            base_image="$_REGISTRY/$2"
-            shift 2
+        exit 0
+      ;;
+      --from)
+        if [ "$1" ]; then
+          base_image="$_REGISTRY/$1"
+          shift
         else
-            base_image="$_REGISTRY/$_REGISTRY_USER/gridware-base"
+          action_die "from parameter requires a value"
         fi
-        app="$1"
-        if [ -z "$app" ]; then
+          ;;
+      --*)
+        action_die "Unknown argument: $arg"
+        ;;
+      *)
+
+        # Assume everything else is supposed to be an app
+
+        if [ -z "$arg" ]; then
             action_die "please specify a package"
-        elif ! echo "$app" | grep -q '.*/.*/.*'; then
+        elif ! echo "$arg" | grep -q '.*/.*/.*'; then
             action_die "please specify the package using the format <type>/<name>/<version>"
-        elif [ "$($_ALCES gridware list "${_GRIDWARE_REPO}/$app" | wc -l)" != "1" ]; then
-            action_die "package not found: $app"
+        elif [ "$($_ALCES gridware list "${_GRIDWARE_REPO}/$arg" | wc -l)" != "1" ]; then
+            action_die "package not found: $arg"
         fi
 
-        if [ "$2" == "--variant" ]; then
-            if [ "$3" ]; then
-                variant="--variant $3"
-                name=gridware-$(echo "$app" | sed "s,\(.*\)/\(.*\)/,\1/\2_$3/,g" | tr '/' '-' | tr '[A-Z]' '[a-z]')
-            else
-                action_die "variant parameter requires a value"
-            fi
+        if [[ "$1" == "--variant" ]]; then
+          if [ "$2" ]; then
+            package="$arg:$2"
+            shift 2
+          else
+            action_die "variant parameter requires a value"
+          fi
         else
-            name=gridware-$(echo "$app" | tr '/' '-' | tr '[A-Z]' '[a-z]')
+          package="$arg"
+          name="$name-$arg"
         fi
+        packages+=($package)
+    esac
 
-        tag="$_REGISTRY/$_REGISTRY_USER/$name"
+  done
 
-        action_emit "Building Gridware container '$name'..."
-        echo ""
+  tag="$_REGISTRY/$_REGISTRY_USER/$name"
 
-        build_dir="$(mktemp -d /tmp/gridware.docker.build.XXXXXXXX)"
-        cat <<EOF > "${build_dir}"/Dockerfile
+  action_emit "Building Gridware container '$name'..."
+  echo ""
+
+  build_dir="$(mktemp -d /tmp/gridware.docker.build.XXXXXXXX)"
+  cat <<EOF > "${build_dir}"/Dockerfile
 FROM ${base_image}
 MAINTAINER Alces Software Ltd. <support@alces-software.com>
-LABEL Alces Gridware - $app
+LABEL Alces Gridware - $name
+EOF
 
+  for package in "${packages[@]}"; do
+    # Include a gridware install command for each package
+    variant=${package#*:}
+    pkg_name=${package%:*}
+    if [[ "$variant" != "$pkg_name" ]]; then
+      variant="--variant ${variant}"
+    else
+      variant=""
+    fi
+
+    cat <<EOF >> "${build_dir}"/Dockerfile
 RUN /opt/clusterware/bin/alces gridware install \
 --binary --binary-only --binary-depends \
 --non-interactive --yes $variant \
-${_GRIDWARE_REPO}/$app && \
-yum clean all
-
-RUN echo "$app" >> /opt/gridware/etc/defaults
+${_GRIDWARE_REPO}/$pkg_name && \
+yum clean all && \
+echo "$pkg_name" >> /opt/gridware/etc/defaults
 EOF
-        set -o pipefail
-        if ! docker build -t "$tag:latest" "$build_dir" 2>&1 | sed 's/^/  >>> /g'; then
-            rm -rf "$build_dir"
-            echo ""
-            action_die "unable to build Gridware container '$name'"
-        else
-            rm -rf "$build_dir"
-        fi
-    fi
+  done
+
+  set -o pipefail
+  if ! docker build -t "$tag:latest" "$build_dir" 2>&1 | sed 's/^/  >>> /g'; then
+      rm -rf "$build_dir"
+      echo ""
+      action_die "unable to build Gridware container '$name'"
+  else
+      rm -rf "$build_dir"
+  fi
 }
 
 cw_BINNAME="alces gridware"

--- a/gridware/libexec/gridware/actions/docker_help
+++ b/gridware/libexec/gridware/actions/docker_help
@@ -27,7 +27,7 @@ main() {
     shift
 
     case $action in
-        help|build|list|push|run)
+        help|build|list|pull|push|run|share|start-registry)
             help_for_${action}
             ;;
         ?*)
@@ -63,7 +63,7 @@ help_for_list() {
 
   DESCRIPTION:
 
-    List available Gridware containers.
+    List available Gridware container images.
 
 EOF
 }
@@ -72,22 +72,22 @@ help_for_build() {
     cat <<EOF
   SYNOPSIS:
 
-    alces gridware docker build [OPTIONS] <package> [--variant <variant>]
+    alces gridware docker build [OPTIONS] <package> [--variant <variant>] [<package> [--variant <variant] ...]
 
   DESCRIPTION:
 
-    Build a new Gridware container for Gridware package <package>,
-    supplying an optional <variant>.
+    Build a new Gridware container image for Gridware package <package>,
+    supplying an optional <variant>. Multiple packages can be specified.
 
-    The parameters are ignored when building the base container.
+    The parameters are ignored when building the base container image.
 
   OPTIONS:
 
     --base
-      Build the Gridware base container.
+      Build the Gridware base container image.
 
     --from <container>
-      Specify a different Gridware base container to use when building
+      Specify a different Gridware base container image to use when building
       the container for <package>.
 
 EOF
@@ -101,13 +101,27 @@ help_for_push() {
 
   DESCRIPTION:
 
-    Push the built Gridware container for <package> to the configured
+    Push the built Gridware container image for <package> to the configured
     Docker container registry.
 
   OPTIONS:
 
     --base
-      Push the Gridware base container.
+      Push the Gridware base container image.
+
+EOF
+}
+
+help_for_pull() {
+    cat <<EOF
+  SYNOPSIS:
+
+    alces gridware docker pull <package>
+
+  DESCRIPTION:
+
+    Pull a prebuilt Gridware container image for <package> from the configured
+    Docker container registry.
 
 EOF
 }
@@ -152,6 +166,43 @@ help_for_run() {
 EOF
 }
 
+
+help_for_share() {
+    cat <<EOF
+  SYNOPSIS:
+
+    alces gridware docker share <package>
+
+  DESCRIPTION:
+
+    Share the Gridware container image for <package> with other nodes in the
+    cluster.
+
+    The image must already be available on the node from which this command is
+    run (e.g. have been used with 'alces gridware docker pull' or 'alces
+    gridware docker run'). Other nodes in the cluster will automatically import
+    the image, making it available to run on each node.
+
+EOF
+}
+
+help_for_start-registry() {
+    cat <<EOF
+  SYNOPSIS:
+
+    alces gridware docker start-registry
+
+  DESCRIPTION:
+
+    Run a local Docker image repository.
+
+    This command will start a Docker container running a Docker image repository
+    configured on port 5000. Images can then be pushed and pulled to the
+    repository as per the Docker documentation, from any node in the cluster.
+
+EOF
+}
+
 general_help() {
     local binname
     binname="${cw_BINNAME% *}"
@@ -168,11 +219,14 @@ general_help() {
   COMMANDS:
 
 EOF
-printf "    %-27s  %s\n" "$binname help" "More help about this command."
-printf "    %-27s  %s\n" "$binname list" "List available Gridware containers."
-printf "    %-27s  %s\n" "$binname run" "Run a containerized Gridware application."
-printf "    %-27s  %s\n" "$binname build" "Build a containerized Gridware application."
-printf "    %-27s  %s\n" "$binname push" "Push a built container to the Docker registry."
+printf "  %-27s  %s\n" "$cw_BINNAME help" "More help about this command."
+printf "  %-27s  %s\n" "$cw_BINNAME list" "List available Gridware containers."
+printf "  %-27s  %s\n" "$cw_BINNAME run" "Run a containerized Gridware application."
+printf "  %-27s  %s\n" "$cw_BINNAME build" "Build a containerized Gridware application."
+printf "  %-27s  %s\n" "$cw_BINNAME pull" "Push a container image from a Docker registry."
+printf "  %-27s  %s\n" "$cw_BINNAME push" "Push a built container image to the Docker registry."
+printf "  %-27s  %s\n" "$cw_BINNAME share" "Share a container image with other nodes in this cluster."
+printf "  %-27s  %s\n" "$cw_BINNAME start-registry" "Start a local Docker registry."
 cat <<EOF
 
 Please report bugs to support@alces-software.com

--- a/gridware/libexec/gridware/actions/docker_help
+++ b/gridware/libexec/gridware/actions/docker_help
@@ -72,7 +72,7 @@ help_for_build() {
     cat <<EOF
   SYNOPSIS:
 
-    alces gridware docker build [OPTIONS] <package> [--variant <variant>] [<package> [--variant <variant] ...]
+    alces gridware docker build [OPTIONS] <package> [--variant <variant>] [<package> [--variant <variant>] ...]
 
   DESCRIPTION:
 
@@ -89,6 +89,13 @@ help_for_build() {
     --from <container>
       Specify a different Gridware base container image to use when building
       the container for <package>.
+
+    --name <name>
+      Specify a name for the image. If not specified, a name based on the
+      selected packages will be generated.
+
+    --script <scriptfile>
+      Specify a job script to run by default in the container image.
 
 EOF
 }
@@ -162,6 +169,11 @@ help_for_run() {
       at '/job/work' and '/job/output'.  The <directory>/input will be
       mapped into the container at '/job/input'.  Defaults to the name
       of the <package>.
+
+    --mount /path/on/host:/path/in/container
+      Specify additional volumes to mount in the container. It is not possible
+      to override the '/job/input', '/job/output' and '/job/work' directories
+      described above.
 
 EOF
 }

--- a/gridware/libexec/gridware/actions/docker_list
+++ b/gridware/libexec/gridware/actions/docker_list
@@ -37,7 +37,7 @@ setup() {
 }
 
 main() {
-    local suffix
+    local img tag id shared suffix
     suffix="$1"
     if [ "$suffix" ]; then
         suffix='*'"${suffix}"'*'
@@ -47,8 +47,17 @@ main() {
     docker search "${_REGISTRY}"/${_REGISTRY_USER}/gridware-${suffix} --limit 100 --no-trunc | \
         tail -n+2 | cut -f1 -d" " | cut -c16- | sort | sed 's/^/  /g'
     echo ""
-    echo "Local:"
-    docker images | grep "/gridware-${resuffix}" | cut -f1 -d" " | cut -f2- -d'-' | sort | sed 's/^/  /g'
+    echo "Local (* indicates shared):"
+    for img in `docker images --no-trunc --format "{{.Repository}}:{{.ID}}" | grep "/gridware-${resuffix}" | cut -f1 -d" " | cut -f2- -d'-' | sort`; do
+      tag=${img%%:*}
+      id=${img##*:}
+      if [ -f "/opt/gridware/docker/exports/${id}" ]; then
+        shared="* "
+      else
+        shared="  "
+      fi
+      echo "${shared}${tag#*-}"
+    done
 }
 
 cw_BINNAME="alces gridware"

--- a/gridware/libexec/gridware/actions/docker_pull
+++ b/gridware/libexec/gridware/actions/docker_pull
@@ -41,6 +41,10 @@ main() {
 
   image="$1"
 
+  if [ -z "$image" ]; then
+    action_die "Please specify an image to pull."
+  fi
+
   if [ "${image%/*}" == "${image}" ]; then
       image="${_REGISTRY}/${_REGISTRY_USER}/gridware-${image}"
   fi

--- a/gridware/libexec/gridware/actions/docker_pull
+++ b/gridware/libexec/gridware/actions/docker_pull
@@ -1,0 +1,65 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+setup() {
+  local a xdg_config
+  IFS=: read -a xdg_config <<< "${XDG_CONFIG_HOME:-$HOME/.config}:${XDG_CONFIG_DIRS:-/etc/xdg}"
+  for a in "${xdg_config[@]}"; do
+    if [ -e "${a}"/clusterware/config.vars.sh ]; then
+        source "${a}"/clusterware/config.vars.sh
+        break
+    fi
+  done
+  if [ -z "${cw_ROOT}" ]; then
+    echo "$0: unable to locate clusterware configuration"
+    exit 1
+  fi
+  kernel_load
+}
+
+main() {
+  local image
+
+  image="$1"
+
+  if [ "${image%/*}" == "${image}" ]; then
+      image="${_REGISTRY}/${_REGISTRY_USER}/gridware-${image}"
+  fi
+
+  docker pull "$image"
+}
+
+setup
+require action
+require files
+
+r=$(type -p docker)
+if [ $? != 0 ] || [ ! -x "$r" ]; then
+  action_die "unable to locate Docker installation"
+fi
+
+files_load_config gridware
+
+_REGISTRY=${cw_GRIDWARE_docker_registry:-docker.io}
+_REGISTRY_USER=${cw_GRIDWARE_docker_registry_user:-alces}
+
+main "$@"

--- a/gridware/libexec/gridware/actions/docker_run
+++ b/gridware/libexec/gridware/actions/docker_run
@@ -37,20 +37,11 @@ setup() {
 }
 
 main() {
-    local run_args image appname input_dir work_dir output_dir use_mpi
+    local run_args image appname input_dir work_dir output_dir
     if [ "$1" == "--workdir" ]; then
         appname="$2"
         shift 2
     fi
-
-    if [[ "$1" == "--mpi" ]]; then
-      if ! docker network inspect gridware-mpi 2&>1 >/dev/null; then
-        action_die "Docker MPI not configured, cannot use MPI."
-      fi
-      use_mpi="--mpi"
-      shift
-    fi
-
     image="$1"
     run_args=("${@:2}")
     appname="${appname:-$image}"
@@ -83,9 +74,7 @@ main() {
              "${_REGISTRY}/$image" \
              "$work_dir" \
              "$input_dir" \
-             "$output_dir" \
-             "$use_mpi" \
-             "${run_args[@]}"
+             "$output_dir" "${run_args[@]}"
     else
         if [ "${run_args[0]}" == "--script" ]; then
             if [ -f "${run_args[1]}" ]; then
@@ -117,9 +106,7 @@ main() {
                 "${_REGISTRY}/$image" \
                 "$work_dir" \
                 "$input_dir" \
-                "$output_dir" \
-                "$use_mpi" \
-                "${run_args[@]}" 2>&1 | sed 's/^/  >>> /g'; then
+                "$output_dir" "${run_args[@]}" 2>&1 | sed 's/^/  >>> /g'; then
             echo ""
             action_emit "Job completed successfully."
             echo ""

--- a/gridware/libexec/gridware/actions/docker_run
+++ b/gridware/libexec/gridware/actions/docker_run
@@ -37,11 +37,20 @@ setup() {
 }
 
 main() {
-    local run_args image appname input_dir work_dir output_dir
+    local run_args image appname input_dir work_dir output_dir use_mpi
     if [ "$1" == "--workdir" ]; then
         appname="$2"
         shift 2
     fi
+
+    if [[ "$1" == "--mpi" ]]; then
+      if ! docker network inspect gridware-mpi 2&>1 >/dev/null; then
+        action_die "Docker MPI not configured, cannot use MPI."
+      fi
+      use_mpi="--mpi"
+      shift
+    fi
+
     image="$1"
     run_args=("${@:2}")
     appname="${appname:-$image}"
@@ -74,7 +83,9 @@ main() {
              "${_REGISTRY}/$image" \
              "$work_dir" \
              "$input_dir" \
-             "$output_dir" "${run_args[@]}"
+             "$output_dir" \
+             "$use_mpi" \
+             "${run_args[@]}"
     else
         if [ "${run_args[0]}" == "--script" ]; then
             if [ -f "${run_args[1]}" ]; then
@@ -106,7 +117,9 @@ main() {
                 "${_REGISTRY}/$image" \
                 "$work_dir" \
                 "$input_dir" \
-                "$output_dir" "${run_args[@]}" 2>&1 | sed 's/^/  >>> /g'; then
+                "$output_dir" \
+                "$use_mpi" \
+                "${run_args[@]}" 2>&1 | sed 's/^/  >>> /g'; then
             echo ""
             action_emit "Job completed successfully."
             echo ""

--- a/gridware/libexec/gridware/actions/docker_share
+++ b/gridware/libexec/gridware/actions/docker_share
@@ -62,6 +62,9 @@ require files
 require handler
 require process
 
+# root is required to broadcast the gridware-docker-exports event
+process_reexec_sudo "$@"
+
 r=$(type -p docker)
 if [ $? != 0 -o ! -x "$r" ]; then
     action_die "unable to locate Docker installation"

--- a/gridware/libexec/gridware/actions/docker_share
+++ b/gridware/libexec/gridware/actions/docker_share
@@ -37,19 +37,30 @@ setup() {
 }
 
 main() {
-  local image_name
+  local image_id image_name
   image_name="gridware-${1}"
 
-  docker save -o "${cw_GRIDWARE_root:-/opt/gridware}/docker/exports/${image_name}.tar" "$_REGISTRY/$_REGISTRY_USER/$image_name"
-  chmod 0644 "${cw_GRIDWARE_root:-/opt/gridware}/docker/exports/${image_name}.tar"
+  image_id=$(docker image inspect --format='{{.Id}}' "$_REGISTRY/$_REGISTRY_USER/$image_name" | sed -e "s/sha256://")
+
+  if [[ $? -eq 0 ]]; then
+
+    docker save -o "${cw_GRIDWARE_root:-/opt/gridware}/docker/exports/${image_id}" "$_REGISTRY/$_REGISTRY_USER/$image_name"
+    chmod 0644 "${cw_GRIDWARE_root:-/opt/gridware}/docker/exports/${image_id}"
+
+    handler_broadcast gridware-docker-exports
+  else
+    echo "Unable to find image for $1."
+    return 1
+  fi
 }
 
 cw_BINNAME="alces gridware"
 
 setup
 require action
-require process
 require files
+require handler
+require process
 
 r=$(type -p docker)
 if [ $? != 0 -o ! -x "$r" ]; then

--- a/gridware/libexec/gridware/actions/docker_share
+++ b/gridware/libexec/gridware/actions/docker_share
@@ -40,7 +40,7 @@ main() {
   local image_name
   image_name="gridware-${1}"
 
-  docker save -o "${cw_GRIDWARE_root:-/opt/gridware}/docker/exports/${image_name}.tar" "${image_name}"
+  docker save -o "${cw_GRIDWARE_root:-/opt/gridware}/docker/exports/${image_name}.tar" "$_REGISTRY/$_REGISTRY_USER/$image_name"
 }
 
 cw_BINNAME="alces gridware"

--- a/gridware/libexec/gridware/actions/docker_share
+++ b/gridware/libexec/gridware/actions/docker_share
@@ -40,9 +40,10 @@ main() {
   local image_id image_name
   image_name="gridware-${1}"
 
+  set -o pipefail
   image_id=$(docker image inspect --format='{{.Id}}' "$_REGISTRY/$_REGISTRY_USER/$image_name" | sed -e "s/sha256://")
 
-  if [[ $? -eq 0 ]]; then
+  if [[ $? -eq 0 && ! -z "$image_id" ]]; then
 
     docker save -o "${cw_GRIDWARE_root:-/opt/gridware}/docker/exports/${image_id}" "$_REGISTRY/$_REGISTRY_USER/$image_name"
     chmod 0644 "${cw_GRIDWARE_root:-/opt/gridware}/docker/exports/${image_id}"

--- a/gridware/libexec/gridware/actions/docker_share
+++ b/gridware/libexec/gridware/actions/docker_share
@@ -41,6 +41,7 @@ main() {
   image_name="gridware-${1}"
 
   docker save -o "${cw_GRIDWARE_root:-/opt/gridware}/docker/exports/${image_name}.tar" "$_REGISTRY/$_REGISTRY_USER/$image_name"
+  chmod 0644 "${cw_GRIDWARE_root:-/opt/gridware}/docker/exports/${image_name}.tar"
 }
 
 cw_BINNAME="alces gridware"

--- a/gridware/libexec/gridware/actions/docker_share
+++ b/gridware/libexec/gridware/actions/docker_share
@@ -1,0 +1,65 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+setup() {
+    local a xdg_config
+    IFS=: read -a xdg_config <<< "${XDG_CONFIG_HOME:-$HOME/.config}:${XDG_CONFIG_DIRS:-/etc/xdg}"
+    for a in "${xdg_config[@]}"; do
+        if [ -e "${a}"/clusterware/config.vars.sh ]; then
+            source "${a}"/clusterware/config.vars.sh
+            break
+        fi
+    done
+    if [ -z "${cw_ROOT}" ]; then
+        echo "$0: unable to locate clusterware configuration"
+        exit 1
+    fi
+    kernel_load
+}
+
+main() {
+  local image_name
+  image_name="gridware-${1}"
+
+  docker save -o "${cw_GRIDWARE_root:-/opt/gridware}/docker/exports/${image_name}.tar" "${image_name}"
+}
+
+cw_BINNAME="alces gridware"
+
+setup
+require action
+require process
+require files
+
+r=$(type -p docker)
+if [ $? != 0 -o ! -x "$r" ]; then
+    action_die "unable to locate Docker installation"
+elif ! process_reexec_sg docker --plain "$@"; then
+    action_die "unable to find Docker group"
+fi
+
+files_load_config gridware
+
+_REGISTRY=${cw_GRIDWARE_docker_registry:-docker.io}
+_REGISTRY_USER=${cw_GRIDWARE_docker_registry_user:-alces}
+
+main "$@"

--- a/gridware/libexec/gridware/actions/docker_start_registry
+++ b/gridware/libexec/gridware/actions/docker_start_registry
@@ -1,0 +1,74 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+setup() {
+    local a xdg_config
+    IFS=: read -a xdg_config <<< "${XDG_CONFIG_HOME:-$HOME/.config}:${XDG_CONFIG_DIRS:-/etc/xdg}"
+    for a in "${xdg_config[@]}"; do
+        if [ -e "${a}"/clusterware/config.vars.sh ]; then
+            source "${a}"/clusterware/config.vars.sh
+            break
+        fi
+    done
+    if [ -z "${cw_ROOT}" ]; then
+        echo "$0: unable to locate clusterware configuration"
+        exit 1
+    fi
+    kernel_load
+}
+
+main() {
+  local registry_volume
+
+  registry_volume="${cw_GRIDWARE_root}/docker/registry"
+  mkdir -p "$registry_volume"
+
+  docker run -d -p 5000:5000 --name registry \
+    -v "$registry_volume":/var/lib/registry \
+    -v "$cw_GRIDWARE_root/docker/certificates/private":/certs
+    -e REGISTRY_HTTP_TLS_CERTIFICATE="/certs/cert.pem" \
+    -e REGISTRY_HTTP_TLS_KEY="/certs/key.pem" \
+    registry:2
+
+}
+
+cw_BINNAME="alces gridware"
+
+setup
+require action
+require files
+require handler
+require process
+
+# root is required to read the SSL certificates
+process_reexec_sudo "$@"
+
+r=$(type -p docker)
+if [ $? != 0 -o ! -x "$r" ]; then
+    action_die "unable to locate Docker installation"
+elif ! process_reexec_sg docker --plain "$@"; then
+    action_die "unable to find Docker group"
+fi
+
+files_load_config gridware
+
+main "$@"

--- a/gridware/libexec/gridware/actions/docker_start_registry
+++ b/gridware/libexec/gridware/actions/docker_start_registry
@@ -44,7 +44,7 @@ main() {
 
   docker run -d -p 5000:5000 --name registry \
     -v "$registry_volume":/var/lib/registry \
-    -v "$cw_GRIDWARE_root/docker/certificates/private":/certs
+    -v "$cw_GRIDWARE_root/docker/certificates/private":/certs \
     -e REGISTRY_HTTP_TLS_CERTIFICATE="/certs/cert.pem" \
     -e REGISTRY_HTTP_TLS_KEY="/certs/key.pem" \
     registry:2

--- a/gridware/libexec/gridware/actions/docker_start_registry
+++ b/gridware/libexec/gridware/actions/docker_start_registry
@@ -39,6 +39,8 @@ setup() {
 main() {
   local registry_volume
 
+  files_load_config config config/cluster
+
   registry_volume="${cw_GRIDWARE_root}/docker/registry"
   mkdir -p "$registry_volume"
 
@@ -48,6 +50,10 @@ main() {
     -e REGISTRY_HTTP_TLS_CERTIFICATE="/certs/cert.pem" \
     -e REGISTRY_HTTP_TLS_KEY="/certs/key.pem" \
     registry:2
+
+  if [[ $? -eq 0 ]]; then
+    echo "Started Docker repository at ${cw_CLUSTER_hostname}:5000"
+  fi
 
 }
 

--- a/gridware/libexec/share/docker-run
+++ b/gridware/libexec/share/docker-run
@@ -70,11 +70,6 @@ main() {
 
     job_uuid=$(uuid)
 
-    if [[ "$1" == "--mpi" ]]; then
-      use_mpi="--net gridware-mpi"
-      shift
-    fi
-
     mounts=("$work_dir:$_INTERNAL_ROOT/work" "$input_dir:$_INTERNAL_ROOT/input" "$output_dir:$_INTERNAL_ROOT/output")
 
     while [[ "$1" == "--mount" ]]; do
@@ -140,7 +135,6 @@ main() {
            --env "INPUT_DIR=$_INTERNAL_ROOT/input" \
            --env "OUTPUT_DIR=$_INTERNAL_ROOT/output" \
            --user "$_UID:$_GID" \
-           "$use_mpi" \
            $job_uuid \
            "${launcher[@]}"
 

--- a/gridware/libexec/share/docker-run
+++ b/gridware/libexec/share/docker-run
@@ -40,13 +40,23 @@ setup() {
     kernel_load
 }
 
+join_by() {
+  local d=$1
+  shift
+  echo -n "$1"
+  shift
+  printf "%s" "${@/#/$d}"
+}
+
 main() {
     local image work_dir input_dir output_dir job_uuid launcher entrypoint interactive
+    local m mount_src mount_dest mounts
     image="$1"
     work_dir="$2"
     input_dir="${3}"
     output_dir="${4}"
-    run_args=("${@:5}")
+
+    shift 4
 
     if [ -z "$work_dir" ]; then
         action_die "please specify work directory."
@@ -59,6 +69,33 @@ main() {
     fi
 
     job_uuid=$(uuid)
+
+    mounts=("$work_dir:$_INTERNAL_ROOT/work" "$input_dir:$_INTERNAL_ROOT/input" "$output_dir:$_INTERNAL_ROOT/output")
+
+    while [[ "$1" == "--mount" ]]; do
+      if [ -z "$2" ]; then
+        action_die "--mount option requires an argument."
+      fi
+
+      mount_src=${2%:*}
+      mount_dest=${2#*:}
+
+      if [[ "$mount_src" == "$2" ]]; then
+        action_die "Volume mounts should be specified as /path/on/host:/path/in/container."
+      fi
+
+      for m in "work" "input" "output"; do
+        if [[ "$mount_dest" == "${_INTERNAL_ROOT}/${m}" || "$mount_dest" == "${_INTERNAL_ROOT}/${m}/"* ]]; then
+          action_die "Cannot override mount point ${_INTERNAL_ROOT}/${m}."
+        fi
+      done
+
+      mounts+=("${mount_src}:${mount_dest}")
+      shift 2
+    done
+
+    run_args=("${@}")
+
     if [ "${run_args[0]}" == "--interactive" ]; then
         interactive="-it"
         if [ "${run_args[1]}" ]; then
@@ -93,9 +130,7 @@ main() {
 
     set +e
     docker run $interactive --rm=true \
-           -v "$work_dir:$_INTERNAL_ROOT/work" \
-           -v "$input_dir:$_INTERNAL_ROOT/input" \
-           -v "$output_dir:$_INTERNAL_ROOT/output" \
+           -v $(join_by " -v " "${mounts[@]}") \
            --env "WORK_DIR=$_INTERNAL_ROOT/work" \
            --env "INPUT_DIR=$_INTERNAL_ROOT/input" \
            --env "OUTPUT_DIR=$_INTERNAL_ROOT/output" \

--- a/gridware/libexec/share/docker-run
+++ b/gridware/libexec/share/docker-run
@@ -70,6 +70,11 @@ main() {
 
     job_uuid=$(uuid)
 
+    if [[ "$1" == "--mpi" ]]; then
+      use_mpi="--net gridware-mpi"
+      shift
+    fi
+
     mounts=("$work_dir:$_INTERNAL_ROOT/work" "$input_dir:$_INTERNAL_ROOT/input" "$output_dir:$_INTERNAL_ROOT/output")
 
     while [[ "$1" == "--mount" ]]; do
@@ -135,6 +140,7 @@ main() {
            --env "INPUT_DIR=$_INTERNAL_ROOT/input" \
            --env "OUTPUT_DIR=$_INTERNAL_ROOT/output" \
            --user "$_UID:$_GID" \
+           "$use_mpi" \
            $job_uuid \
            "${launcher[@]}"
 

--- a/gridware/libexec/share/docker-run
+++ b/gridware/libexec/share/docker-run
@@ -44,12 +44,18 @@ main() {
     local image work_dir input_dir output_dir job_uuid launcher entrypoint interactive workload
     image="$1"
     work_dir="$2"
-    input_dir="${3:-$work_dir}"
-    output_dir="${4:-$work_dir}"
+    input_dir="${3}"
+    output_dir="${4}"
     run_args=("${@:5}")
 
     if [ -z "$work_dir" ]; then
-        action_die "please specify work directory and, optionally, input and output directories"
+        action_die "please specify work directory."
+    fi
+    if [ -z "$input_dir" ]; then
+        action_die "please specify input directory."
+    fi
+    if [ -z "$output_dir" ]; then
+        action_die "please specify output directory."
     fi
 
     job_uuid=$(uuid)

--- a/gridware/libexec/share/docker-run
+++ b/gridware/libexec/share/docker-run
@@ -41,7 +41,7 @@ setup() {
 }
 
 main() {
-    local image work_dir input_dir output_dir job_uuid launcher entrypoint interactive workload
+    local image work_dir input_dir output_dir job_uuid launcher entrypoint interactive
     image="$1"
     work_dir="$2"
     input_dir="${3}"


### PR DESCRIPTION
This PR makes a number of enhancements to Gridware's nascent Docker support:

- It's now possible to share Docker images from the master node to slave nodes via an NFS-shared directory. Running `alces gridware docker share <imagename>` on the master node will export the image to `/opt/gridware/docker/exports` and broadcast a `gridware-docker-exports` event to the cluster. On receipt of this event slave nodes will import from the shared directory any images not currently installed locally.

- It's also now possible to run a cluster-wide Docker registry, with the `alces gridware docker start-registry` command, as an alternative method of sharing images.

- It's possible to specify multiple Gridware packages to install when building an image with `alces gridware docker build`.

- It's possible to pull Gridware Docker images using `alces gridware docker pull`.

- It's possible to specify a script to be executed by default in containers running an image built with `alces gridware docker build`, using the new `--script` option.

- The automatically-generated image name can be overridden by supplying the `--name` argument to `alces gridware docker build`.

- Shell autocompletion for `alces gridware docker` and subcommands has been added.

- It is possible to specify additional volume mounts when running a container with `alces gridware docker run`. These are specified as `--mount /path/on/host:/path/in/container` and are in addition to the existing volumes for `/job/input`, `/job/work` and `/job/output`, which it is not permitted to override.

- Metadata in images built with `alces gridware docker build` now use the modern Docker standard `LABEL` command and include more useful metadata.

Note that this PR does not include work towards using Docker for MPI workloads, as that investigation is ongoing.

Related PRs:
- `clusterware-handlers`: https://github.com/alces-software/clusterware-handlers/pull/74
