### PR TITLE
Correctly transform default queue name before using it.

### DIFF
--- a/openlava/openlava.functions.sh
+++ b/openlava/openlava.functions.sh
@@ -46,13 +46,14 @@ pending_jobs = jobs.count {|l| l.split(/\s+/)[2] == 'PEND'}
 running_jobs = jobs.count {|l| l.split(/\s+/)[2] == 'RUN'}
 cores_per_node = ${cores_per_node:-2}
 cores_req = queues.reduce(0) {|memo,l| memo + l.split(/\s+/)[8].to_i}
+default_queue="${default_queue}".gsub(/[-\.]/, "_")
 results = {
   "openlava_job_queue" => pending_jobs,
   "openlava_job_run" => running_jobs,
   "openlava_job_total" => jobs.length,
   "openlava_cores_req" => cores_req,
   "openlava_nodes_req" => ((cores_req * 1.0) / cores_per_node).ceil,
-  "openlava_queue_${default_queue}_nodes_req" => ((cores_req * 1.0) / cores_per_node).ceil,
+  "openlava_queue_#{default_queue}_nodes_req" => ((cores_req * 1.0) / cores_per_node).ceil,
 }
 results.each { |k,v| puts "#{k}=#{v}" }
 RUBY

--- a/pbspro/pbspro.functions.sh
+++ b/pbspro/pbspro.functions.sh
@@ -46,13 +46,14 @@ running_job_count = jobs.count {|l| l.split(/\s+/)[9] == 'R'}
 cores_per_node = ${cores_per_node:-2}
 cores_req = pending_jobs.reduce(0) {|memo,l| memo + l.split(/\s+/)[6].to_i}
 nodes_req = pending_jobs.reduce(0) {|memo,l| memo + l.split(/\s+/)[5].to_i}
+default_queue="${default_queue}".gsub(/[-\.]/, "_")
 results = {
   "pbspro_job_queue" => pending_jobs.length,
   "pbspro_job_run" => running_job_count,
   "pbspro_job_total" => running_job_count + pending_jobs.length,
   "pbspro_cores_req" => cores_req,
   "pbspro_nodes_req" => nodes_req,
-  "pbspro_queue_${default_queue}_nodes_req" => nodes_req
+  "pbspro_queue_#{default_queue}_nodes_req" => nodes_req
 }
 results.each { |k,v| puts "#{k}=#{v}" }
 RUBY

--- a/torque/torque.functions.sh
+++ b/torque/torque.functions.sh
@@ -46,13 +46,14 @@ running_job_count = jobs.count {|l| l.split(/\s+/)[9] == 'R'}
 cores_per_node = ${cores_per_node:-2}
 cores_req = pending_jobs.reduce(0) {|memo,l| memo + l.split(/\s+/)[6].to_i}
 nodes_req = pending_jobs.reduce(0) {|memo,l| memo + l.split(/\s+/)[5].to_i}
+default_queue="${default_queue}".gsub(/[-\.]/, "_")
 results = {
   "torque_job_queue" => pending_jobs.length,
   "torque_job_run" => running_job_count,
   "torque_job_total" => running_job_count + pending_jobs.length,
   "torque_cores_req" => cores_req,
   "torque_nodes_req" => nodes_req,
-  "torque_queue_${default_queue}_nodes_req" => nodes_req
+  "torque_queue_#{default_queue}_nodes_req" => nodes_req
 }
 results.each { |k,v| puts "#{k}=#{v}" }
 RUBY


### PR DESCRIPTION
Fixes https://github.com/alces-software/clusterware-handlers/issues/75.