### PR TITLE
Add Docker-for-MPI support to Gridware

### DIFF
--- a/gridware/docker/gridware-base/Dockerfile
+++ b/gridware/docker/gridware-base/Dockerfile
@@ -2,6 +2,7 @@ FROM alces/clusterware-el7:1.7
 LABEL maintainer="Alces Software Ltd. <support@alces-software.com>" \
       description="Alces Gridware - base image"
 
+RUN yum -y install openssh-server
 RUN /opt/clusterware/bin/alces service install gridware && /opt/clusterware/bin/alces gridware init && yum clean all
 RUN mkdir -p /opt/gridware/bin
 COPY launcher.sh /opt/gridware/bin/launcher.sh

--- a/gridware/docker/gridware-base/Dockerfile
+++ b/gridware/docker/gridware-base/Dockerfile
@@ -2,7 +2,7 @@ FROM alces/clusterware-el7:1.7
 LABEL maintainer="Alces Software Ltd. <support@alces-software.com>" \
       description="Alces Gridware - base image"
 
-RUN yum -y install openssh-server
+RUN yum -y install openssh-server openssh-clients
 RUN /opt/clusterware/bin/alces service install gridware && /opt/clusterware/bin/alces gridware init && yum clean all
 RUN mkdir -p /opt/gridware/bin
 COPY launcher.sh /opt/gridware/bin/launcher.sh

--- a/gridware/docker/gridware-base/launcher.sh
+++ b/gridware/docker/gridware-base/launcher.sh
@@ -15,6 +15,13 @@ EOF
     fi
 }
 
+_configure_sshd() {
+  # Generate an SSH key for the server
+  ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
+  # Remove references to keys we've not generated
+  sed -i -e "/ssh_host_e/d" /etc/ssh/sshd_config
+}
+
 if shopt -q login_shell; then
     if [ -f /opt/gridware/etc/defaults ]; then
         for a in $(cat /opt/gridware/etc/defaults); do
@@ -39,7 +46,10 @@ if [ -z "$1" ]; then
         echo ""
     fi
 else
-    if [ -x "$1" -o -x "$(type -P "$1")" ]; then
+    if [[ "$1" == "--mpi" ]]; then
+      _configure_sshd
+      /usr/sbin/sshd -D
+    elif [ -x "$1" -o -x "$(type -P "$1")" ]; then
         exec "$@"
     else
         echo "$1 not found. Did you mean '--script $@'?"

--- a/gridware/libexec/gridware/actions/docker_help
+++ b/gridware/libexec/gridware/actions/docker_help
@@ -175,6 +175,19 @@ help_for_run() {
       to override the '/job/input', '/job/output' and '/job/work' directories
       described above.
 
+    --mpi[=N]
+      Run the job in an MPI environment, starting N copies of the image in a
+      "slave" configuration, before running a container for the MPI "master"
+      process. If not specified, N defaults to 2.
+
+      Two files will be made available within the container at '/job/work/':
+        - '/job/work/hosts' is a hosts file containing entries for each slave
+          container being run as part of the job
+        - '/job/work/hostlist' is a file listing the IP addresses of each
+          slave container, one per line.
+      These files may be used to specify a list of hosts for 'mpirun' or
+      similar.
+
 EOF
 }
 

--- a/gridware/libexec/gridware/actions/docker_run
+++ b/gridware/libexec/gridware/actions/docker_run
@@ -44,7 +44,7 @@ main() {
     fi
 
     if [[ "$1" == "--mpi"* ]]; then
-      if [ ! -d "${cw_ROOT}/var/lib/customizer/feature-configure-docker-mpi" ]; then
+      if [ ! "$(docker network ls -f 'name=gridware-mpi' -q)" ]; then
         action_die "Docker MPI not configured, cannot use MPI."
       fi
       use_mpi="$1"

--- a/gridware/libexec/gridware/actions/docker_run
+++ b/gridware/libexec/gridware/actions/docker_run
@@ -43,11 +43,11 @@ main() {
         shift 2
     fi
 
-    if [[ "$1" == "--mpi" ]]; then
+    if [[ "$1" == "--mpi"* ]]; then
       if [ ! -d "${cw_ROOT}/var/lib/customizer/feature-configure-docker-mpi" ]; then
         action_die "Docker MPI not configured, cannot use MPI."
       fi
-      use_mpi="--mpi"
+      use_mpi="$1"
       shift
     fi
 

--- a/gridware/libexec/gridware/actions/docker_run
+++ b/gridware/libexec/gridware/actions/docker_run
@@ -83,7 +83,9 @@ main() {
              "${_REGISTRY}/$image" \
              "$work_dir" \
              "$input_dir" \
-             "$output_dir" "${run_args[@]}"
+             "$output_dir" \
+             $use_mpi \
+             "${run_args[@]}"
     else
         if [ "${run_args[0]}" == "--script" ]; then
             if [ -f "${run_args[1]}" ]; then
@@ -115,7 +117,9 @@ main() {
                 "${_REGISTRY}/$image" \
                 "$work_dir" \
                 "$input_dir" \
-                "$output_dir" "${run_args[@]}" 2>&1 | sed 's/^/  >>> /g'; then
+                "$output_dir" \
+                $use_mpi \
+                "${run_args[@]}" 2>&1 | sed 's/^/  >>> /g'; then
             echo ""
             action_emit "Job completed successfully."
             echo ""

--- a/gridware/libexec/gridware/actions/docker_run
+++ b/gridware/libexec/gridware/actions/docker_run
@@ -42,6 +42,15 @@ main() {
         appname="$2"
         shift 2
     fi
+
+    if [[ "$1" == "--mpi" ]]; then
+      if ! docker network inspect gridware-mpi >/dev/null 2>&1; then
+        action_die "Docker MPI not configured, cannot use MPI."
+      fi
+      use_mpi="--mpi"
+      shift
+    fi
+
     image="$1"
     run_args=("${@:2}")
     appname="${appname:-$image}"

--- a/gridware/libexec/gridware/actions/docker_run
+++ b/gridware/libexec/gridware/actions/docker_run
@@ -44,7 +44,7 @@ main() {
     fi
 
     if [[ "$1" == "--mpi" ]]; then
-      if ! docker network inspect gridware-mpi >/dev/null 2>&1; then
+      if [ ! -d "${cw_ROOT}/var/lib/customizer/feature-configure-docker-mpi" ]; then
         action_die "Docker MPI not configured, cannot use MPI."
       fi
       use_mpi="--mpi"

--- a/gridware/libexec/share/docker-run
+++ b/gridware/libexec/share/docker-run
@@ -96,8 +96,12 @@ main() {
 
     run_args=("${@}")
 
-    if [ "${run_args[0]}" == "--mpi" ]; then
+    if [[ "${run_args[0]}" == "--mpi"* ]]; then
       use_mpi="--network gridware-mpi"
+      if [[ ${run_args[0]#*=} != ${run_args[0]} ]]; then
+        # a number of slaves has been specified
+        mpi_slaves=${run_args[0]#*=}
+      fi
       run_args=(${run_args[@]:1})
     fi
 
@@ -149,7 +153,7 @@ EOF
 
     if [[ ! -z "$use_mpi" ]]; then
       # This step currently gives some scary-looking errors that aren't actually errors
-      docker service create --network gridware-mpi --replicas 2 --name ${job_uuid}-service ${job_uuid} --mpi >> $work_dir/docker.log
+      docker service create --network gridware-mpi --replicas ${mpi_slaves:-2} --name ${job_uuid}-service ${job_uuid} --mpi >> $work_dir/docker.log
       # Now wait until all replicas have been created
       while true; do
         replicas=$(docker service ls --filter name=${job_uuid}-service | tail -n -1 | cut -d' ' -f7)

--- a/gridware/libexec/share/docker-run
+++ b/gridware/libexec/share/docker-run
@@ -137,7 +137,6 @@ EOF
    IdentityFile %d/.ssh/id_rsa
    StrictHostKeyChecking  no
 EOF
-     chmod 600 $work_dir/ssh/
      cat <<EOF >>$work_dir/Dockerfile
      COPY ssh /home/$SUDO_USER/.ssh
      RUN chown -R $_UID:$_GID /home/$SUDO_USER/.ssh

--- a/gridware/libexec/share/docker-run
+++ b/gridware/libexec/share/docker-run
@@ -121,6 +121,15 @@ main() {
            useradd -m -u $SUDO_UID $SUDO_USER \
            >> $work_dir/docker.log
 
+   if [[ ! -z "$use_mpi" ]]; then
+     # set up SSH key for sshd in container so that all copies of the temp image
+     # can log into each other
+     mkdir -p $work_dir/ssh
+     ssh-keygen -t rsa -f $work_dir/ssh/id_rsa -N ''
+     cp $work_dir/ssh/id_rsa.pub $work_dir/ssh/authorized_keys
+     docker cp $work_dir/ssh $job_uuid:~$SUDO_USER/.ssh
+   fi
+
     docker commit \
            $(docker ps -aq --filter name=${job_uuid}$) \
            $job_uuid \

--- a/gridware/libexec/share/docker-run
+++ b/gridware/libexec/share/docker-run
@@ -114,12 +114,12 @@ main() {
         fi
     fi
 
-    docker run \
-           --entrypoint "" \
-           --name $job_uuid \
-           "${image}" \
-           useradd -m -u $SUDO_UID $SUDO_USER \
-           >> $work_dir/docker.log
+    cat <<EOF >$work_dir/Dockerfile
+FROM ${image}
+
+RUN useradd -m -u $SUDO_UID $SUDO_USER
+
+EOF
 
    if [[ ! -z "$use_mpi" ]]; then
      # set up SSH key for sshd in container so that all copies of the temp image
@@ -127,15 +127,14 @@ main() {
      mkdir -p $work_dir/ssh
      ssh-keygen -t rsa -f $work_dir/ssh/id_rsa -N ''
      cp $work_dir/ssh/id_rsa.pub $work_dir/ssh/authorized_keys
-     docker cp $work_dir/ssh $job_uuid:~$SUDO_USER/.ssh
+     chmod 600 $work_dir/ssh/
+     cat <<EOF >>$work_dir/Dockerfile
+     COPY ssh /home/$SUDO_USER/.ssh
+     RUN chown -R $_UID:$_GID /home/$SUDO_USER/.ssh
+EOF
    fi
 
-    docker commit \
-           $(docker ps -aq --filter name=${job_uuid}$) \
-           $job_uuid \
-           >> $work_dir/docker.log
-
-    docker rm $job_uuid >> $work_dir/docker.log
+    docker build -t $job_uuid $work_dir >> $work_dir/docker.log
 
     set +e
     docker run $interactive --rm=true \

--- a/gridware/libexec/share/docker-run
+++ b/gridware/libexec/share/docker-run
@@ -156,7 +156,7 @@ EOF
       # Assemble a hosts file
        containers=$(docker service ps --no-trunc -f "desired-state=running" ${job_uuid}-service | tail -n +2 | awk '{print $2"."$1}')
        for container in $containers; do
-         ip=$(docker inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}""{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" $container)
+         ip=$(docker inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" $container)
          echo "$container $ip" >> $work_dir/hosts
        done
 

--- a/gridware/libexec/share/docker-run
+++ b/gridware/libexec/share/docker-run
@@ -206,6 +206,7 @@ RUBY
            --env "WORK_DIR=$_INTERNAL_ROOT/work" \
            --env "INPUT_DIR=$_INTERNAL_ROOT/input" \
            --env "OUTPUT_DIR=$_INTERNAL_ROOT/output" \
+           --env "OMPI_MCA_btl_tcp_if_include=eth0" \
            --user "$_UID:$_GID" \
            $use_mpi \
            $job_uuid \

--- a/gridware/libexec/share/docker-run
+++ b/gridware/libexec/share/docker-run
@@ -141,6 +141,8 @@ EOF
      cat <<EOF >>$work_dir/Dockerfile
      COPY ssh /home/$SUDO_USER/.ssh
      RUN chown -R $_UID:$_GID /home/$SUDO_USER/.ssh
+     RUN for m in \`cat /opt/gridware/etc/defaults\`; do echo "module load \$m" >> /home/$SUDO_USER/.modules; done && \
+         chown $_UID:$_GID /home/$SUDO_USER/.modules
 EOF
    fi
 

--- a/gridware/libexec/share/docker-run
+++ b/gridware/libexec/share/docker-run
@@ -152,6 +152,13 @@ EOF
     docker build -t $job_uuid $work_dir >> $work_dir/docker.log
 
     if [[ ! -z "$use_mpi" ]]; then
+      # Share temporary image with slave nodes
+      docker save -o "${cw_GRIDWARE_root:-/opt/gridware}/docker/exports/${job_uuid}" "${job_uuid}"
+      chmod 0644 "${cw_GRIDWARE_root:-/opt/gridware}/docker/exports/${job_uuid}"
+
+      handler_broadcast gridware-docker-exports
+      sleep 30  # Wait for slaves to import image
+
       # This step currently gives some scary-looking errors that aren't actually errors
       docker service create --network gridware-mpi --replicas ${mpi_slaves:-2} --name ${job_uuid}-service ${job_uuid} --mpi >> $work_dir/docker.log
       # Now wait until all replicas have been created
@@ -187,6 +194,7 @@ EOF
 
     if [[ ! -z "$use_mpi" ]]; then
       docker service rm ${job_uuid}-service >> $work_dir/docker.log
+      rm "${cw_GRIDWARE_root:-/opt/gridware}/docker/exports/${job_uuid}"
     fi
     docker rmi --force $job_uuid >> $work_dir/docker.log
 }

--- a/gridware/libexec/share/docker-run
+++ b/gridware/libexec/share/docker-run
@@ -141,6 +141,27 @@ EOF
 
     docker build -t $job_uuid $work_dir >> $work_dir/docker.log
 
+    if [[ ! -z "$use_mpi" ]]; then
+      # This step currently gives some scary-looking errors that aren't actually errors
+      docker service create --network gridware-mpi --replicas 2 --name ${job_uuid}-service ${job_uuid} --mpi >> $work_dir/docker.log
+      # Now wait until all replicas have been created
+      while true; do
+        replicas=$(docker service ls --filter name=${job_uuid}-service | tail -n -1 | cut -d' ' -f7)
+        ready=${replicas%/*}
+        total=${replicas#*/}
+        if [[ "$ready" == "$total" ]]; then break; fi
+        sleep 5
+      done
+
+      # Assemble a hosts file
+       containers=$(docker service ps --no-trunc -f "desired-state=running" ${job_uuid}-service | tail -n +2 | awk '{print $2"."$1}')
+       for container in $containers; do
+         ip=$(docker inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}""{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" $container)
+         echo "$container $ip" >> $work_dir/hosts
+       done
+
+    fi
+
     set +e
     docker run $interactive --rm=true \
            -v $(join_by " -v " "${mounts[@]}") \
@@ -152,6 +173,9 @@ EOF
            $job_uuid \
            "${launcher[@]}"
 
+    if [[ ! -z "$use_mpi" ]]; then
+      docker service rm ${job_uuid}-service >> $work_dir/docker.log
+    fi
     docker rmi $job_uuid >> $work_dir/docker.log
 }
 

--- a/gridware/libexec/share/docker-run
+++ b/gridware/libexec/share/docker-run
@@ -134,7 +134,7 @@ EOF
      # set up SSH key for sshd in container so that all copies of the temp image
      # can log into each other
      mkdir -p $work_dir/ssh
-     ssh-keygen -t rsa -f $work_dir/ssh/id_rsa -N ''
+     ssh-keygen -t rsa -f $work_dir/ssh/id_rsa -N '' >> $work_dir/docker.log
      cp $work_dir/ssh/id_rsa.pub $work_dir/ssh/authorized_keys
      cat <<EOF > $work_dir/ssh/config
  Host *

--- a/gridware/libexec/share/docker-run
+++ b/gridware/libexec/share/docker-run
@@ -156,28 +156,47 @@ EOF
       docker save -o "${cw_GRIDWARE_root:-/opt/gridware}/docker/exports/${job_uuid}" "${job_uuid}"
       chmod 0644 "${cw_GRIDWARE_root:-/opt/gridware}/docker/exports/${job_uuid}"
 
-      handler_broadcast gridware-docker-exports
-      sleep 30  # Wait for slaves to import image
+      for node in $(docker node ls -f "role=worker" | tail -n -1 | cut -d ' ' -f6); do
+        # Force each node to import the image!
+        ssh $node -c docker load -i "${cw_GRIDWARE_root:-/opt/gridware}/docker/exports/${job_uuid}"
+      done
 
       # This step currently gives some scary-looking errors that aren't actually errors
       docker service create --network gridware-mpi --replicas ${mpi_slaves:-2} --name ${job_uuid}-service ${job_uuid} --mpi >> $work_dir/docker.log
       # Now wait until all replicas have been created
       while true; do
-        replicas=$(docker service ls --filter name=${job_uuid}-service | tail -n -1 | cut -d' ' -f7)
+        replicas=$(docker service ls --filter name=${job_uuid}-service | tail -n -1 | sed -e "s/ \+/ /g" | cut -d' ' -f4)
         ready=${replicas%/*}
         total=${replicas#*/}
+        echo "${ready} of ${total} slaves ready"
         if [[ "$ready" == "$total" ]]; then break; fi
         sleep 5
       done
 
       sleep 5  # wait for containers to get their IP addresses from Docker
       # Assemble a hosts file
-       containers=$(docker service ps --no-trunc -f "desired-state=running" ${job_uuid}-service | tail -n +2 | awk '{print $2"."$1}')
-       for container in $containers; do
-         ip=$(docker inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" $container)
-         echo "$container $ip" >> $work_dir/hosts
-         echo "$ip" >> $work_dir/hostlist
-       done
+      ruby_run <<RUBY
+
+require 'json'
+
+network = JSON.parse(IO.popen("docker network inspect --verbose gridware-mpi").read)[0]
+
+containers = network["Services"]["${job_uuid}-service"]["Tasks"]
+
+File.open("$work_dir/hosts", "w") { |hosts|
+
+  File.open("$work_dir/hostlist", "w") { |hostlist|
+
+    containers.each { |container|
+      hostlist.write("#{container["EndpointIP"]}\n")
+      hosts.write("#{container["Name"]} #{container["EndpointIP"]}\n")
+    }
+
+  }
+
+}
+
+RUBY
 
     fi
 
@@ -202,6 +221,7 @@ EOF
 setup
 require action
 require process
+require ruby
 
 if ! process_reexec_sg docker --plain "$@"; then
    action_die "unable to find group: docker"

--- a/gridware/libexec/share/docker-run
+++ b/gridware/libexec/share/docker-run
@@ -135,6 +135,7 @@ main() {
            --env "INPUT_DIR=$_INTERNAL_ROOT/input" \
            --env "OUTPUT_DIR=$_INTERNAL_ROOT/output" \
            --user "$_UID:$_GID" \
+           $use_mpi \
            $job_uuid \
            "${launcher[@]}"
 

--- a/gridware/libexec/share/docker-run
+++ b/gridware/libexec/share/docker-run
@@ -158,7 +158,7 @@ EOF
 
       for node in $(docker node ls -f "role=worker" | tail -n -1 | cut -d ' ' -f6); do
         # Force each node to import the image!
-        ssh $node -c docker load -i "${cw_GRIDWARE_root:-/opt/gridware}/docker/exports/${job_uuid}"
+        ssh $node docker load -i "${cw_GRIDWARE_root:-/opt/gridware}/docker/exports/${job_uuid}"
       done
 
       # This step currently gives some scary-looking errors that aren't actually errors

--- a/gridware/libexec/share/docker-run
+++ b/gridware/libexec/share/docker-run
@@ -127,6 +127,11 @@ EOF
      mkdir -p $work_dir/ssh
      ssh-keygen -t rsa -f $work_dir/ssh/id_rsa -N ''
      cp $work_dir/ssh/id_rsa.pub $work_dir/ssh/authorized_keys
+     cat <<EOF > $work_dir/ssh/config
+ Host *
+   IdentityFile %d/.ssh/id_rsa
+   StrictHostKeyChecking  no
+EOF
      chmod 600 $work_dir/ssh/
      cat <<EOF >>$work_dir/Dockerfile
      COPY ssh /home/$SUDO_USER/.ssh

--- a/gridware/libexec/share/docker-run
+++ b/gridware/libexec/share/docker-run
@@ -96,6 +96,11 @@ main() {
 
     run_args=("${@}")
 
+    if [ "${run_args[0]}" == "--mpi" ]; then
+      use_mpi="--network gridware-mpi"
+      run_args=(${run_args[@]:1})
+    fi
+
     if [ "${run_args[0]}" == "--interactive" ]; then
         interactive="-it"
         if [ "${run_args[1]}" ]; then
@@ -153,11 +158,13 @@ EOF
         sleep 5
       done
 
+      sleep 5  # wait for containers to get their IP addresses from Docker
       # Assemble a hosts file
        containers=$(docker service ps --no-trunc -f "desired-state=running" ${job_uuid}-service | tail -n +2 | awk '{print $2"."$1}')
        for container in $containers; do
          ip=$(docker inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" $container)
          echo "$container $ip" >> $work_dir/hosts
+         echo "$ip" >> $work_dir/hostlist
        done
 
     fi
@@ -176,7 +183,7 @@ EOF
     if [[ ! -z "$use_mpi" ]]; then
       docker service rm ${job_uuid}-service >> $work_dir/docker.log
     fi
-    docker rmi $job_uuid >> $work_dir/docker.log
+    docker rmi --force $job_uuid >> $work_dir/docker.log
 }
 
 setup


### PR DESCRIPTION
This PR builds on the work in #45 to add a method of running MPI jobs in a containerised Gridware environment.

Gridware app images must be built from a Gridware base image that includes the changes in this PR, which includes an SSH daemon and client that are used in MPI running mode.

Then, running `alces gridware docker run` with the new `--mpi[=N]` flag will start N (default 2) slave containers running an SSH daemon, and execute the given command in a master container as normal.

The master container will have access to a host file containing a list of slave containers' IP addresses and hostnames, as well as a list of just IP addresses.

This also relies on the configuration added to the `configure-docker` customization profile in https://github.com/alces-software/flight-profiles/pull/8 to set up the cross-node Docker network used for cross-container communication.

Related PRs:
 - `clusterware-services`: #45 (Gridware Docker enhancements)
 - `clusterware-handlers`: https://github.com/alces-software/clusterware-handlers/pull/77
 - `flight-profiles`: https://github.com/alces-software/flight-profiles/pull/8