### PR TITLE
Prevents `alces gridware init` running as a non-sudo user

### DIFF
--- a/gridware/libexec/gridware/actions/init
+++ b/gridware/libexec/gridware/actions/init
@@ -231,7 +231,9 @@ require distro
 require ui
 require files
 require ruby
+require process
 
+process_reexec_sudo
 files_load_config gridware
 files_load_config --optional gridware config/gridware
 


### PR DESCRIPTION
Fix that prevents running `alces gridware init` as a non-sudo user. Fixes the issue as discussed in https://github.com/alces-software/clusterware/issues/224.

The command now uses `process_rexec_sudo` so the `alces` user will sill be able to run `alces gridware init` however as `sudo`. It does mean that users in the `gridware` group that do not have `sudo` permission will not be able to run the command anymore. 