### PR TITLE
Use EC2 network VPC CIDR if we're on an EC2 network.

### DIFF
--- a/alces-flight-www/metadata.yml
+++ b/alces-flight-www/metadata.yml
@@ -97,7 +97,12 @@ component-base:
       echo "cw_CLUSTER_FIREWALL_rule_http=\"INPUT -p tcp --dport ${cw_ALCES_FLIGHT_WWW_http_port:-80} -j ACCEPT\"" >> "${cw_ROOT}"/etc/cluster-firewall/static.d/alces-flight-www.rc
 
       files_load_config config config/cluster
-      prv_net=$(network_get_iface_network "${cw_CLUSTER_iface:-$(network_get_first_iface)}")
+
+      if network_is_ec2; then
+        prv_net=$(network_get_ec2_vpc_cidr_block)
+      else
+        prv_net=$(network_get_iface_network "${cw_CLUSTER_iface:-$(network_get_first_iface)}")
+      fi
 
       _install_nginx_conf geo http
       sed -i -e "s,_PRV_NETWORK_,$prv_net,g" \


### PR DESCRIPTION
`$cw_CLUSTER_iface` isn't present on EC2 and `network_get_first_iface` might not get the correct network. So, when running on EC2, treat everything on the VPC as internal traffic and don't redirect it to HTTPS.