### PR TITLE
Allow personality data to set compute queue config

### DIFF
--- a/clusterware-compute/libexec/compute/actions/reduce
+++ b/clusterware-compute/libexec/compute/actions/reduce
@@ -55,8 +55,8 @@ main() {
   max=$(compute_max "${queue}")
   if [ "$current_size" -le "$size" ]; then
       action_die "refusing to reduce: queue already satisfies capacity (currently: $current_size)"
-  elif [ "$min" -lt "$size" ]; then
-      action_die "cannot expand: requested size ($size) under minimum ($min)"
+  elif [ "$min" -gt "$size" ]; then
+      action_die "cannot reduce: requested size ($size) under minimum ($min)"
   else
     compute_call POST "${queue}" "${size}" "${min}" "${max}"
     action_die "queue reduced to ${size}" 0


### PR DESCRIPTION
The `alces compute ...` commands provide tracon with the cluster's
name and network domain.  tracon uses these to determine the
cloudformation stack name.  This does not work for clusters launched
with Flight Launch as the stack name also contains a hash of the user's
email address.

This commit allows Flight Launch to specify the cluster name and domain
that should be used by the `alces compute ...` commands.